### PR TITLE
refactor FinishTool to builtin tools for agents

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -163,6 +163,7 @@ This repo has two python packages, with unit tests specifically written for each
 
 <CODE>
 - Avoid hacky trick like `sys.path.insert` when resolving package dependency
+- Use existing packages/libraries instead of implementing yourselves whenever possible.
 </CODE>
 
 <TESTING>

--- a/openhands/core/agent/codeact_agent/codeact_agent.py
+++ b/openhands/core/agent/codeact_agent/codeact_agent.py
@@ -8,52 +8,19 @@ from litellm.types.utils import (
     Message as LiteLLMMessage,
     ModelResponse,
 )
-from pydantic import Field, ValidationError
+from pydantic import ValidationError
 
 from openhands.core.context import EnvContext, PromptManager
 from openhands.core.conversation import ConversationCallbackType, ConversationState
 from openhands.core.llm import LLM, Message, TextContent, get_llm_metadata
 from openhands.core.logger import get_logger
-from openhands.core.tool import ActionBase, ObservationBase, Tool, ToolAnnotations
+from openhands.core.tool import BUILT_IN_TOOLS, ActionBase, ObservationBase, Tool
 
 from ..base import AgentBase
 
 
 logger = get_logger(__name__)
 
-"""Finish tool implementation."""
-
-
-class FinishAction(ActionBase):
-    message: str = Field(description="Final message to send to the user.")
-
-
-TOOL_DESCRIPTION = """Signals the completion of the current task or conversation.
-
-Use this tool when:
-- You have successfully completed the user's requested task
-- You cannot proceed further due to technical limitations or missing information
-
-The message should include:
-- A clear summary of actions taken and their results
-- Any next steps for the user
-- Explanation if you're unable to complete the task
-- Any follow-up questions if more information is needed
-"""
-
-
-FINISH_TOOL = Tool(
-    name="finish",
-    input_schema=FinishAction,
-    description=TOOL_DESCRIPTION,
-    annotations=ToolAnnotations(
-        title="finish",
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
 
 
 class CodeActAgent(AgentBase):
@@ -65,8 +32,9 @@ class CodeActAgent(AgentBase):
         system_prompt_filename: str = "system_prompt.j2",
         cli_mode: bool = True,
     ) -> None:
-        assert FINISH_TOOL not in tools, "Finish tool is automatically included and should not be provided."
-        super().__init__(llm=llm, tools=tools + [FINISH_TOOL], env_context=env_context)
+        for tool in BUILT_IN_TOOLS:
+            assert tool not in tools, f"{tool} is automatically included and should not be provided."
+        super().__init__(llm=llm, tools=tools + BUILT_IN_TOOLS, env_context=env_context)
         self.prompt_manager = PromptManager(
             prompt_dir=os.path.join(os.path.dirname(__file__), "prompts"),
             system_prompt_filename=system_prompt_filename,
@@ -167,12 +135,6 @@ class CodeActAgent(AgentBase):
             err = f"Error validating args {tool_call.function.arguments} for tool '{tool.name}': {e}"
             logger.error(err)
             state.history.messages.append(Message(role="tool", name=tool.name, tool_call_id=tool_call.id, content=[TextContent(text=err)]))
-            return state
-
-        # Early return for finish action (no need for tool execution)
-        if isinstance(action, FinishAction):
-            assert tool.name == FINISH_TOOL.name, "FinishAction must be used with the finish tool"
-            state.agent_finished = True
             return state
 
         # Execute actions!

--- a/openhands/core/tool/__init__.py
+++ b/openhands/core/tool/__init__.py
@@ -1,5 +1,6 @@
 """OpenHands runtime package."""
 
+from .builtin_tools import BUILT_IN_TOOLS, FinishTool
 from .tool import ActionBase, ObservationBase, Tool, ToolAnnotations, ToolExecutor
 
 
@@ -9,4 +10,6 @@ __all__ = [
     "ToolExecutor",
     "ActionBase",
     "ObservationBase",
+    "FinishTool",
+    "BUILT_IN_TOOLS",
 ]

--- a/openhands/core/tool/builtin_tools.py
+++ b/openhands/core/tool/builtin_tools.py
@@ -1,0 +1,55 @@
+"""Implementing essential tools that doesn't interact with the environment.
+
+These are built in and are *required* for the agent to work.
+
+For tools that require interacting with the environment, add them to `openhands/tools`.
+"""
+from pydantic import Field
+
+from openhands.core.tool import ActionBase, ObservationBase, Tool, ToolAnnotations, ToolExecutor
+
+
+class FinishAction(ActionBase):
+    message: str = Field(description="Final message to send to the user.")
+
+class FinishObservation(ObservationBase):
+    message: str = Field(description="Final message sent to the user.")
+
+    @property
+    def agent_observation(self) -> str:
+        return self.message
+
+TOOL_DESCRIPTION = """Signals the completion of the current task or conversation.
+
+Use this tool when:
+- You have successfully completed the user's requested task
+- You cannot proceed further due to technical limitations or missing information
+
+The message should include:
+- A clear summary of actions taken and their results
+- Any next steps for the user
+- Explanation if you're unable to complete the task
+- Any follow-up questions if more information is needed
+"""
+
+class FinishExecutor(ToolExecutor):
+    def __call__(self, action: FinishAction) -> FinishObservation:
+        return FinishObservation(message=action.message)
+
+
+FinishTool = Tool(
+    name="finish",
+    input_schema=FinishAction,
+    output_schema=FinishObservation,
+    description=TOOL_DESCRIPTION,
+    executor=FinishExecutor(),
+    annotations=ToolAnnotations(
+        title="finish",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+
+BUILT_IN_TOOLS = [FinishTool]

--- a/openhands/core/tool/builtin_tools.py
+++ b/openhands/core/tool/builtin_tools.py
@@ -6,7 +6,7 @@ For tools that require interacting with the environment, add them to `openhands/
 """
 from pydantic import Field
 
-from openhands.core.tool import ActionBase, ObservationBase, Tool, ToolAnnotations, ToolExecutor
+from .tool import ActionBase, ObservationBase, Tool, ToolAnnotations, ToolExecutor
 
 
 class FinishAction(ActionBase):


### PR DESCRIPTION
This helps standardize the SDK tool interfaces. We have two sources of tools:
- built-ins: these are essential tools like "think", "finish" that do NOT interact with the environment (e.g., read-only, idempotent, non-openworld, non-destructive). ConversationManager
- `openhands/tools`: these are actual tools (bash/editors) that will have an effect on the environment.

