### PR TITLE
Conversation: make state.events.append a default callback; remove manual appends in CodeActAgent

### DIFF
--- a/openhands/core/agent/codeact_agent/codeact_agent.py
+++ b/openhands/core/agent/codeact_agent/codeact_agent.py
@@ -167,5 +167,4 @@ class CodeActAgent(AgentBase):
         # Set conversation state
         if tool.name == FinishTool.name:
             state.agent_finished = True
-        # Persist observation via default on_event appender
         return obs_event

--- a/openhands/core/agent/codeact_agent/codeact_agent.py
+++ b/openhands/core/agent/codeact_agent/codeact_agent.py
@@ -52,7 +52,6 @@ class CodeActAgent(AgentBase):
         if len(messages) == 0:
             # Prepare system message
             event = SystemPromptEvent(source="agent", system_prompt=self.system_message, tools=[t.to_openai_tool() for t in self.tools.values()])
-            # emit event; Conversation default callback persists it
             on_event(event)
 
     def step(

--- a/openhands/core/tests/conversation/test_conversation_default_callback.py
+++ b/openhands/core/tests/conversation/test_conversation_default_callback.py
@@ -1,0 +1,57 @@
+
+from typing import List
+from unittest.mock import MagicMock
+
+from openhands.core.agent.base import AgentBase
+from openhands.core.conversation import Conversation
+from openhands.core.conversation.state import ConversationState
+from openhands.core.conversation.types import ConversationCallbackType
+from openhands.core.event.llm_convertible import MessageEvent, SystemPromptEvent
+from openhands.core.llm import Message, TextContent
+
+
+class DummyAgent(AgentBase):
+    def __init__(self):
+        super().__init__(llm=MagicMock(name="LLM"), tools=[])
+        self.prompt_manager = MagicMock()
+
+    def init_state(self, state: ConversationState, on_event: ConversationCallbackType) -> None:
+        event = SystemPromptEvent(source="agent", system_prompt=TextContent(text="dummy"), tools=[])
+        on_event(event)
+
+    def step(self, state: ConversationState, on_event: ConversationCallbackType) -> None:
+        on_event(MessageEvent(source="agent", llm_message=Message(role="assistant", content=[TextContent(text="ok")])) )
+
+
+def test_default_callback_appends_on_init():
+    agent = DummyAgent()
+    events_seen: List[str] = []
+
+    convo = Conversation(agent=agent, callbacks=[lambda e: events_seen.append(e.id)])
+
+    assert len(convo.state.events) == 1
+    assert isinstance(convo.state.events[0], SystemPromptEvent)
+    assert convo.state.events[0].id in events_seen
+
+
+def test_send_message_appends_once():
+    agent = DummyAgent()
+    seen_ids: List[str] = []
+
+    def user_cb(event):
+        seen_ids.append(event.id)
+
+    convo = Conversation(agent=agent, callbacks=[user_cb])
+
+    convo.send_message(Message(role="user", content=[TextContent(text="hi")]))
+
+    # Now we should have two events: initial system prompt and the user message
+    assert len(convo.state.events) == 2
+    assert isinstance(convo.state.events[-1], MessageEvent)
+
+    # Ensure the user message event is appended exactly once in state
+    last_id = convo.state.events[-1].id
+    assert sum(1 for e in convo.state.events if e.id == last_id) == 1
+
+    # Ensure callback saw both events
+    assert set(seen_ids) == {e.id for e in convo.state.events}


### PR DESCRIPTION
Summary
- Make state.events.append a default callback in Conversation so agents can just call on_event(event)
- Remove manual state.events.append calls in CodeActAgent to avoid duplication and confusion
- Add unit tests verifying events are appended exactly once

What/Why
This change simplifies event handling and ensures consistent behavior across the codebase. Agents now emit events via on_event, and Conversation persists them to state by default. This addresses readability concerns and removes scattered state mutations.

Changes
- Conversation
  - Add default event appender callback
  - Compose callbacks as [visualizer, user callbacks..., default appender] to preserve existing ordering semantics
  - send_message no longer appends directly; it only emits the event
- CodeActAgent
  - init_state: stop manual append of SystemPromptEvent
  - step: stop manual appends of MessageEvent; rely on on_event
  - _get_action_events: stop manual appends on error paths; rely on on_event
  - _execute_action_events: rely on on_event for ObservationEvent persistence
- Tests
  - New tests under openhands/core/tests/conversation/test_conversation_default_callback.py verifying:
    - Default callback persists init system event
    - User message is appended exactly once and callbacks receive events

Backward compatibility
- No breaking changes. Event lifecycle remains the same externally; only internal wiring is simplified. Visualizer callbacks and user-provided callbacks continue to operate normally.

Validation
- Ran pre-commit (ruff + pyright) on changed files – passed
- Ran core tests and tools tests separately due to environment memory limits; all passed
- Ran integration test test_hello_world_integration_with_mocked_llm – passed

Fixes
- Closes #51

Notes
- Full test suite occasionally OOMs in this environment unrelated to these changes; running in segments avoids this and shows green across relevant areas.

Co-authored-by: openhands <openhands@all-hands.dev>

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/861c0125fda04fbeb20c584f91262cab)