### PR TITLE
Core context condensation implementation

### DIFF
--- a/openhands/core/context/view.py
+++ b/openhands/core/context/view.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from logging import getLogger
+from typing import overload
+
+from pydantic import BaseModel
+
+from openhands.core.event.base import EventBase, LLMConvertibleEvent
+from openhands.core.event.context import Condensation, CondensationRequest
+from openhands.core.event.llm_convertible import MessageEvent
+from openhands.core.llm import Message, TextContent
+
+
+logger = getLogger(__name__)
+
+
+class View(BaseModel):
+    """Linearly ordered view of events.
+
+    Produced by a condenser to indicate the included events are ready to process as LLM input.
+    """
+
+    events: list[LLMConvertibleEvent]
+    unhandled_condensation_request: bool = False
+
+    def __len__(self) -> int:
+        return len(self.events)
+
+    # To preserve list-like indexing, we ideally support slicing and position-based indexing.
+    # The only challenge with that is switching the return type based on the input type -- we
+    # can mark the different signatures for MyPy with `@overload` decorators.
+
+    @overload
+    def __getitem__(self, key: slice) -> list[LLMConvertibleEvent]: ...
+
+    @overload
+    def __getitem__(self, key: int) -> LLMConvertibleEvent: ...
+
+    def __getitem__(self, key: int | slice) -> LLMConvertibleEvent | list[LLMConvertibleEvent]:
+        if isinstance(key, slice):
+            start, stop, step = key.indices(len(self))
+            return [self[i] for i in range(start, stop, step)]
+        elif isinstance(key, int):
+            return self.events[key]
+        else:
+            raise ValueError(f"Invalid key type: {type(key)}")
+
+    @staticmethod
+    def from_events(events: list[EventBase]) -> View:
+        """Create a view from a list of events, respecting the semantics of any condensation events."""
+        forgotten_event_ids: set[str] = set()
+        for event in events:
+            if isinstance(event, Condensation):
+                forgotten_event_ids.update(event.forgotten)
+                # Make sure we also forget the condensation action itself
+                forgotten_event_ids.add(event.id)
+            if isinstance(event, CondensationRequest):
+                forgotten_event_ids.add(event.id)
+
+        kept_events = [event for event in events if event.id not in forgotten_event_ids and isinstance(event, LLMConvertibleEvent)]
+
+        # If we have a summary, insert it at the specified offset.
+        summary: str | None = None
+        summary_offset: int | None = None
+
+        # The relevant summary is always in the last condensation event (i.e., the most recent one).
+        for event in reversed(events):
+            if isinstance(event, Condensation):
+                if event.summary is not None and event.summary_offset is not None:
+                    summary = event.summary
+                    summary_offset = event.summary_offset
+                    break
+
+        if summary is not None and summary_offset is not None:
+            logger.info(f"Inserting summary at offset {summary_offset}")
+
+            kept_events.insert(summary_offset, MessageEvent(llm_message=Message(role="system", content=[TextContent(text=summary)], name="system"), source="environment"))
+
+        # Check for an unhandled condensation request -- these are events closer to the
+        # end of the list than any condensation action.
+        unhandled_condensation_request = False
+        for event in reversed(events):
+            if isinstance(event, Condensation):
+                break
+            if isinstance(event, CondensationRequest):
+                unhandled_condensation_request = True
+                break
+
+        return View(
+            events=kept_events,
+            unhandled_condensation_request=unhandled_condensation_request,
+        )

--- a/openhands/core/event/context.py
+++ b/openhands/core/event/context.py
@@ -1,4 +1,5 @@
 from openhands.core.event.base import EventBase
+from openhands.core.event.types import SourceType
 
 
 class Condensation(EventBase):
@@ -23,6 +24,8 @@ class Condensation(EventBase):
     summary_offset: int | None = None
     """An optional offset to the start of the resulting view indicating where the summary should be inserted."""
 
+    source: SourceType = "environment"
+
     @property
     def forgotten(self) -> list[str]:
         """The list of event IDs that should be forgotten."""
@@ -44,6 +47,8 @@ class CondensationRequest(EventBase):
     Attributes:
         action (str): The action type, namely ActionType.CONDENSATION_REQUEST.
     """
+
+    source: SourceType = "environment"
 
     @property
     def message(self) -> str:

--- a/openhands/core/event/context.py
+++ b/openhands/core/event/context.py
@@ -1,0 +1,94 @@
+from openhands.core.event.base import EventBase
+
+
+class Condensation(EventBase):
+    """This action indicates a condensation of the conversation history is happening.
+
+    There are two ways to specify the events to be forgotten:
+    1. By providing a list of event IDs.
+    2. By providing the start and end IDs of a range of events.
+
+    In the second case, we assume that event IDs are monotonically increasing, and that _all_ events between the start and end IDs are to be forgotten.
+
+    Raises:
+        ValueError: If the optional fields are not instantiated in a valid configuration.
+    """
+    
+    forgotten_event_ids: list[int] | None = None
+    """The IDs of the events that are being forgotten (removed from the `View` given to the LLM)."""
+
+    forgotten_events_start_id: int | None = None
+    """The ID of the first event to be forgotten in a range of events."""
+
+    forgotten_events_end_id: int | None = None
+    """The ID of the last event to be forgotten in a range of events."""
+
+    summary: str | None = None
+    """An optional summary of the events being forgotten."""
+
+    summary_offset: int | None = None
+    """An optional offset to the start of the resulting view indicating where the summary should be inserted."""
+
+    def _validate_field_polymorphism(self) -> bool:
+        """Check if the optional fields are instantiated in a valid configuration."""
+        # For the forgotton events, there are only two valid configurations:
+        # 1. We're forgetting events based on the list of provided IDs, or
+        using_event_ids = self.forgotten_event_ids is not None
+        # 2. We're forgetting events based on the range of IDs.
+        using_event_range = (
+            self.forgotten_events_start_id is not None
+            and self.forgotten_events_end_id is not None
+        )
+
+        # Either way, we can only have one of the two valid configurations.
+        forgotten_event_configuration = using_event_ids ^ using_event_range
+
+        # We also need to check that if the summary is provided, so is the
+        # offset (and vice versa).
+        summary_configuration = (
+            self.summary is None and self.summary_offset is None
+        ) or (self.summary is not None and self.summary_offset is not None)
+
+        return forgotten_event_configuration and summary_configuration
+
+    def __post_init__(self):
+        if not self._validate_field_polymorphism():
+            raise ValueError('Invalid configuration of the optional fields.')
+
+    @property
+    def forgotten(self) -> list[int]:
+        """The list of event IDs that should be forgotten."""
+        # Start by making sure the fields are instantiated in a valid
+        # configuration. We check this whenever the event is initialized, but we
+        # can't make the dataclass immutable so we need to check it again here
+        # to make sure the configuration is still valid.
+        if not self._validate_field_polymorphism():
+            raise ValueError('Invalid configuration of the optional fields.')
+
+        if self.forgotten_event_ids is not None:
+            return self.forgotten_event_ids
+
+        # If we've gotten this far, the start/end IDs are not None.
+        assert self.forgotten_events_start_id is not None
+        assert self.forgotten_events_end_id is not None
+        return list(
+            range(self.forgotten_events_start_id, self.forgotten_events_end_id + 1)
+        )
+
+    @property
+    def message(self) -> str:
+        if self.summary:
+            return f'Summary: {self.summary}'
+        return f'Condenser is dropping the events: {self.forgotten}.'
+
+
+class CondensationRequest(EventBase):
+    """This action is used to request a condensation of the conversation history.
+
+    Attributes:
+        action (str): The action type, namely ActionType.CONDENSATION_REQUEST.
+    """
+
+    @property
+    def message(self) -> str:
+        return 'Requesting a condensation of the conversation history.'

--- a/openhands/core/event/context.py
+++ b/openhands/core/event/context.py
@@ -14,14 +14,8 @@ class Condensation(EventBase):
         ValueError: If the optional fields are not instantiated in a valid configuration.
     """
     
-    forgotten_event_ids: list[int] | None = None
+    forgotten_event_ids: list[str] | None = None
     """The IDs of the events that are being forgotten (removed from the `View` given to the LLM)."""
-
-    forgotten_events_start_id: int | None = None
-    """The ID of the first event to be forgotten in a range of events."""
-
-    forgotten_events_end_id: int | None = None
-    """The ID of the last event to be forgotten in a range of events."""
 
     summary: str | None = None
     """An optional summary of the events being forgotten."""
@@ -29,51 +23,13 @@ class Condensation(EventBase):
     summary_offset: int | None = None
     """An optional offset to the start of the resulting view indicating where the summary should be inserted."""
 
-    def _validate_field_polymorphism(self) -> bool:
-        """Check if the optional fields are instantiated in a valid configuration."""
-        # For the forgotton events, there are only two valid configurations:
-        # 1. We're forgetting events based on the list of provided IDs, or
-        using_event_ids = self.forgotten_event_ids is not None
-        # 2. We're forgetting events based on the range of IDs.
-        using_event_range = (
-            self.forgotten_events_start_id is not None
-            and self.forgotten_events_end_id is not None
-        )
-
-        # Either way, we can only have one of the two valid configurations.
-        forgotten_event_configuration = using_event_ids ^ using_event_range
-
-        # We also need to check that if the summary is provided, so is the
-        # offset (and vice versa).
-        summary_configuration = (
-            self.summary is None and self.summary_offset is None
-        ) or (self.summary is not None and self.summary_offset is not None)
-
-        return forgotten_event_configuration and summary_configuration
-
-    def __post_init__(self):
-        if not self._validate_field_polymorphism():
-            raise ValueError('Invalid configuration of the optional fields.')
-
     @property
-    def forgotten(self) -> list[int]:
+    def forgotten(self) -> list[str]:
         """The list of event IDs that should be forgotten."""
-        # Start by making sure the fields are instantiated in a valid
-        # configuration. We check this whenever the event is initialized, but we
-        # can't make the dataclass immutable so we need to check it again here
-        # to make sure the configuration is still valid.
-        if not self._validate_field_polymorphism():
-            raise ValueError('Invalid configuration of the optional fields.')
-
         if self.forgotten_event_ids is not None:
             return self.forgotten_event_ids
-
-        # If we've gotten this far, the start/end IDs are not None.
-        assert self.forgotten_events_start_id is not None
-        assert self.forgotten_events_end_id is not None
-        return list(
-            range(self.forgotten_events_start_id, self.forgotten_events_end_id + 1)
-        )
+        else:
+            return []
 
     @property
     def message(self) -> str:

--- a/openhands/core/tests/context/test_view.py
+++ b/openhands/core/tests/context/test_view.py
@@ -1,0 +1,239 @@
+from openhands.core.context.view import View
+from openhands.core.event.base import EventBase
+from openhands.core.event.context import Condensation, CondensationRequest
+from openhands.core.event.llm_convertible import MessageEvent
+from openhands.core.llm import Message, TextContent
+
+
+def message_event(content: str) -> MessageEvent:
+    return MessageEvent(llm_message=Message(role="user", content=[TextContent(text=content)]), source="user")
+
+
+def test_view_preserves_uncondensed_lists() -> None:
+    """Tests that the view preserves event lists that don't contain condensation actions."""
+    events: list[EventBase] = [message_event(f"Event {i}") for i in range(5)]
+    view = View.from_events(events)
+    assert len(view) == 5
+    assert view.events == events
+
+
+def test_view_forgets_events() -> None:
+    """Tests that views drop forgotten events and the condensation actions."""
+    message_events: list[EventBase] = [message_event(f"Event {i}") for i in range(5)]
+    message_event_ids: list[str] = [event.id for event in message_events]
+
+    # Build a list of events: M_1, ..., M_5, Condensation
+    # The condensation specifically targets the IDs of all M_i messages
+    events: list[EventBase] = [
+        *message_events,
+        Condensation(forgotten_event_ids=message_event_ids),
+    ]
+
+    # All events should be forgotten and removed.
+    view = View.from_events(events)
+    assert view.events == []
+
+
+def test_view_keeps_non_forgotten_events() -> None:
+    """Tests that views keep non-forgotten events."""
+    message_events: list[EventBase] = [message_event(f"Event {i}") for i in range(5)]
+    message_event_ids: list[str] = [event.id for event in message_events]
+
+    for forgotten_event_id in message_event_ids:
+        events: list[EventBase] = [
+            *message_events,
+            # Instead of forgetting all events like in
+            # `test_view_forgets_events`, in this test we only want to forget
+            # one of the events. That way we can check that the rest of the
+            # events are preserved.
+            Condensation(forgotten_event_ids=[forgotten_event_id]),
+        ]
+
+        view = View.from_events(events)
+
+        # We should have one less message event
+        assert len(view.events) == len(message_events) - 1
+        # And should _not_ have the forgotten event present
+        assert forgotten_event_id not in [event.id for event in view.events]
+
+
+def test_view_inserts_summary() -> None:
+    """Tests that views insert a summary observation at the specified offset."""
+    message_events = [message_event(f"Event {i}") for i in range(5)]
+
+    for offset in range(5):
+        events: list[EventBase] = [
+            *message_events,
+            Condensation(forgotten_event_ids=[], summary="My Summary", summary_offset=offset),
+        ]
+        view = View.from_events(events)
+
+        assert len(view) == 6  # 5 message events + 1 summary observation
+        for index, event in enumerate(view):
+            assert isinstance(event, MessageEvent)
+            assert isinstance(event.llm_message.content[0], TextContent)
+            content = event.llm_message.content[0].text
+            if index == offset:
+                assert content == "My Summary"
+
+            # Events before where the summary is inserted will have content
+            # matching their index.
+            elif index < offset:
+                assert content == f"Event {index}"
+
+            # Events after where the summary is inserted will be offset by one
+            # from the original list.
+            else:
+                assert content == f"Event {index - 1}"
+
+
+def test_no_condensation_action_in_view() -> None:
+    """Ensure that condensation events are never present in the resulting view."""
+    message_events = [message_event(f"Event {i}") for i in range(4)]
+    
+    # Build the event sequence -- we'll pack a condensation in the middle of four
+    # message events (and make sure the condensation drops the first event)
+    events: list[EventBase] = []
+    
+    events.extend(message_events[:2])
+    events.append(Condensation(forgotten_event_ids=[message_events[0].id]))
+    events.extend(message_events[2:])
+    
+    view = View.from_events(events)
+
+    # Check that no condensation is present in the view
+    for event in view:
+        assert not isinstance(event, Condensation)
+
+    # The view should only contain the non-forgotten MessageActions
+    assert len(view) == 3  # Event 1, Event 2, Event 3 (Event 0 was forgotten)
+
+
+def test_unhandled_condensation_request_with_no_condensation() -> None:
+    """Test that unhandled_condensation_request is True when there's a CondensationRequestAction but no CondensationAction."""
+    events: list[EventBase] = [
+        message_event("Event 0"),
+        message_event("Event 1"),
+        CondensationRequest(),
+        message_event("Event 2"),
+    ]
+    view = View.from_events(events)
+
+    # Should be marked as having an unhandled condensation request
+    assert view.unhandled_condensation_request is True
+
+    # CondensationRequestAction should be removed from the view
+    assert len(view) == 3  # Only the MessageActions remain
+    for event in view:
+        assert not isinstance(event, CondensationRequest)
+
+
+def test_handled_condensation_request_with_condensation_action() -> None:
+    """Test that unhandled_condensation_request is False when CondensationAction comes after CondensationRequestAction."""
+    events: list[EventBase] = []
+    events.extend([message_event("Event 0"), message_event("Event 1"), CondensationRequest(), message_event("Event 2")])
+    events.append(Condensation(forgotten_event_ids=[event.id for event in events[:2]]))
+    events.append(message_event("Event 3"))
+    view = View.from_events(events)
+
+    # Should NOT be marked as having an unhandled condensation request
+    assert view.unhandled_condensation_request is False
+
+    # Both CondensationRequestAction and CondensationAction should be removed from the view
+    assert len(view) == 2  # Event 2 and Event 3 (Event 0, 1 forgotten)
+    for event in view:
+        assert not isinstance(event, CondensationRequest)
+        assert not isinstance(event, Condensation)
+
+
+def test_multiple_condensation_requests_pattern() -> None:
+    """Test the pattern with multiple condensation requests and actions."""
+    events: list[EventBase] = [
+        message_event(content="Event 0"),
+        CondensationRequest(),  # First request
+        message_event(content="Event 1"),
+        Condensation(forgotten_event_ids=[]),  # Handles first request
+        message_event(content="Event 2"),
+        CondensationRequest(),  # Second request - should be unhandled
+        message_event(content="Event 3"),
+    ]
+    view = View.from_events(events)
+
+    # Should be marked as having an unhandled condensation request (the second one)
+    assert view.unhandled_condensation_request is True
+
+    # Both CondensationRequests and Condensation should be removed from the view
+    assert len(view) == 4  # Event 0, Event 1, Event 2, Event 3
+    for event in view:
+        assert not isinstance(event, CondensationRequest)
+        assert not isinstance(event, Condensation)
+
+
+def test_condensation_action_before_request() -> None:
+    """Test that CondensationAction before CondensationRequestAction doesn't affect the unhandled status."""
+    events: list[EventBase] = [
+        message_event(content="Event 0"),
+        Condensation(forgotten_event_ids=[]),  # This doesn't handle the later request
+        message_event(content="Event 1"),
+        CondensationRequest(),  # This should be unhandled
+        message_event(content="Event 2"),
+    ]
+    view = View.from_events(events)
+
+    # Should be marked as having an unhandled condensation request
+    assert view.unhandled_condensation_request is True
+
+    # Both CondensationRequestAction and CondensationAction should be removed from the view
+    assert len(view) == 3  # Event 0, Event 1, Event 2
+    for event in view:
+        assert not isinstance(event, CondensationRequest)
+        assert not isinstance(event, Condensation)
+
+
+def test_no_condensation_events() -> None:
+    """Test that unhandled_condensation_request is False when there are no condensation events."""
+    events: list[EventBase] = [
+        message_event(content="Event 0"),
+        message_event(content="Event 1"),
+        message_event(content="Event 2"),
+    ]
+    view = View.from_events(events)
+
+    # Should NOT be marked as having an unhandled condensation request
+    assert view.unhandled_condensation_request is False
+
+    # All events should remain
+    assert len(view) == 3
+    assert view.events == events
+
+
+def test_condensation_request_always_removed_from_view() -> None:
+    """Test that CondensationRequest is always removed from the view regardless of unhandled status."""
+    # Test case 1: Unhandled request
+    events_unhandled: list[EventBase] = [
+        message_event(content="Event 0"),
+        CondensationRequest(),
+        message_event(content="Event 1"),
+    ]
+    view_unhandled = View.from_events(events_unhandled)
+
+    assert view_unhandled.unhandled_condensation_request is True
+    assert len(view_unhandled) == 2  # Only MessageEvents
+    for event in view_unhandled:
+        assert not isinstance(event, CondensationRequest)
+
+    # Test case 2: Handled request
+    events_handled: list[EventBase] = [
+        message_event(content="Event 0"),
+        CondensationRequest(),
+        message_event(content="Event 1"),
+        Condensation(forgotten_event_ids=[]),
+        message_event(content="Event 2"),
+    ]
+    view_handled = View.from_events(events_handled)
+
+    assert view_handled.unhandled_condensation_request is False
+    assert len(view_handled) == 3  # Only MessageEvents
+    for event in view_handled:
+        assert not isinstance(event, CondensationRequest)
+        assert not isinstance(event, Condensation)


### PR DESCRIPTION
This PR ports over the core of the condensation logic from the OSS repo.

Some changes made from the source:
1. `Condensation` objects don't track start/stop IDs, just a list of IDs to forget. New event ID is not "range able" like the ints of old.