### PR TITLE
Fix: Reset agent finished state on follow-up user message in Conversation.run()

### DIFF
--- a/openhands/sdk/conversation/conversation.py
+++ b/openhands/sdk/conversation/conversation.py
@@ -100,6 +100,13 @@ class Conversation:
     def run(self) -> None:
         """Runs the conversation until the agent finishes."""
         iteration = 0
+        # If a follow-up user message was appended externally after the agent
+        # finished, reset the finished flag so the agent can process it.
+        with self.state:
+            if self.state.agent_finished and self.state.events:
+                last_event = self.state.events[-1]
+                if isinstance(last_event, MessageEvent) and last_event.source == "user":
+                    self.state.agent_finished = False
         while not self.state.agent_finished:
             logger.debug(f"Conversation run iteration {iteration}")
             # TODO(openhands): we should add a testcase that test IF:

--- a/tests/sdk/conversation/test_conversation_followup_run_resets.py
+++ b/tests/sdk/conversation/test_conversation_followup_run_resets.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+
+from openhands.sdk.agent.base import AgentBase
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.state import ConversationState
+from openhands.sdk.conversation.types import ConversationCallbackType
+from openhands.sdk.event.llm_convertible import MessageEvent, SystemPromptEvent
+from openhands.sdk.llm import Message, TextContent
+
+
+class DummyAgent(AgentBase):
+    """A minimal agent that marks the conversation finished after it replies once."""
+
+    def __init__(self):
+        super().__init__(llm=MagicMock(name="LLM"), tools=[])
+        self.prompt_manager = MagicMock()
+        self.steps: int = 0
+
+    def init_state(
+        self, state: ConversationState, on_event: ConversationCallbackType
+    ) -> None:
+        event = SystemPromptEvent(
+            source="agent", system_prompt=TextContent(text="dummy"), tools=[]
+        )
+        on_event(event)
+
+    def step(
+        self, state: ConversationState, on_event: ConversationCallbackType
+    ) -> None:
+        # Emit a trivial assistant message and finish the turn
+        on_event(
+            MessageEvent(
+                source="agent",
+                llm_message=Message(role="assistant", content=[TextContent(text="ok")]),
+            )
+        )
+        state.agent_finished = True
+        self.steps += 1
+
+
+def test_followup_message_triggers_new_run_when_finished():
+    agent = DummyAgent()
+    convo = Conversation(agent=agent)
+
+    # First user message and run
+    convo.send_message(Message(role="user", content=[TextContent(text="do it")]))
+    convo.run()
+    assert agent.steps == 1
+
+    # Simulate a follow-up user message being appended (e.g., from UI layer)
+    # without going through Conversation.send_message()
+    user_event = MessageEvent(
+        source="user",
+        llm_message=Message(role="user", content=[TextContent(text="again")]),
+    )
+    convo._on_event(user_event)  # type: ignore[attr-defined]
+
+    # Now run again; run() must reset finished state and process the new message
+    convo.run()
+
+    assert agent.steps == 2, "Agent should run again for the follow-up user message"


### PR DESCRIPTION
Summary
- Fix regression where follow-up user messages were not processed because Conversation.run() didn't reset state.agent_finished when a new user MessageEvent was appended after completion.
- Add unit test to reproduce and prevent regression.

What changed
- openhands/sdk/conversation/conversation.py
  - At the start of run(), if the conversation was finished but the last event is a user MessageEvent, reset state.agent_finished to False within the state lock. This ensures the agent will run again to process the follow-up message.

- tests/sdk/conversation/test_conversation_followup_run_resets.py
  - New test that simulates a complete turn, then appends a user message event directly (bypassing send_message) and asserts that a subsequent run() triggers another agent step.

Rationale
The Conversation.send_message() path already resets agent_finished to False. However, follow-up messages can be appended by external components (e.g., UI) directly via callbacks, bypassing send_message(). In those cases, run() would immediately exit because agent_finished remained True. Resetting at the start of run() based on the most recent user event restores expected behavior without breaking existing flows.

Testing
- Added unit test covering the regression scenario; passes locally.
- Existing conversation default callback tests continue to pass.

Backward compatibility
- No breaking changes. Behavior now matches user expectation: subsequent run() processes newly appended user messages.

Related
- Fixes #92


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c0302712107b40d28f2794c1c624c8af)