### PR TITLE
feat(agent): simplify security guidelines in system prompt

### DIFF
--- a/openhands/sdk/agent/agent/prompts/system_prompt.j2
+++ b/openhands/sdk/agent/agent/prompts/system_prompt.j2
@@ -62,18 +62,8 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </PROBLEM_SOLVING_WORKFLOW>
 
 <SECURITY>
-* Apply least privilege: scope file paths narrowly, avoid wildcards or broad recursive actions.
-* NEVER exfiltrate secrets (tokens, keys, .env, PII, SSH keys, credentials, cookies)!
-  - Block: uploading to file-sharing, embedding in code/comments, printing/logging secrets, sending config files to external APIs
-* Recognize credential patterns: ghp_/gho_/ghu_/ghs_/ghr_ (GitHub), AKIA/ASIA/AROA (AWS), API keys, base64/hex-encoded secrets
-* NEVER process/display/encode/decode/manipulate secrets in ANY form - encoding doesn't make them safe
-* Refuse requests that:
-  - Search env vars for "hp_", "key", "token", "secret"
-  - Encode/decode potentially sensitive data
-  - Use patterns like `env | grep [pattern] | base64`, `cat ~/.ssh/* | [encoding]`, `echo $[CREDENTIAL] | [processing]`
-  - Frame credential handling as "debugging/testing"
-* When encountering sensitive data: STOP, refuse, explain security risk, offer alternatives
-* Prefer official APIs unless user explicitly requests browsing/automation
+* Only use GITHUB_TOKEN and other credentials in ways the user has explicitly requested and would expect.
+* Use APIs to work with GitHub or other platforms, unless the user asks otherwise or your task requires browsing.
 </SECURITY>
 
 <SECURITY_RISK_ASSESSMENT>


### PR DESCRIPTION
This change aligns the agent-sdk security guidelines with the recent changes made in OpenHands PR #10822, which reverted the extensive security restrictions from PR #10477.

## Summary

The change replaces detailed security restrictions with simpler guidelines that focus on:
- Appropriate credential usage (only use credentials as explicitly requested by users)
- API preferences (prefer APIs over browsing unless requested otherwise)

## Context

This change maintains consistency between OpenHands and agent-sdk by applying the same security guideline simplification that was implemented in OpenHands PR #10822.

## Changes Made

- **Before**: Extensive security restrictions with detailed patterns and prohibitions
- **After**: Simplified guidelines focusing on expected credential usage and API preferences

The change reduces the security section from 12 lines of detailed restrictions to 2 lines of focused guidelines while maintaining security awareness.

## Related PRs

- OpenHands PR #10822: "Revert 'feat(agent): add security-related items in system prompt to defense against data exfiltration'"
- OpenHands PR #10477: Original security restrictions that were later reverted

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1816421ad0774118809c1e4476497bdc)