### PR TITLE
Fix issue #10729: Add xai/grok-code-fast-1 to MODELS_WITHOUT_STOP_WORDS

### DIFF
--- a/openhands/sdk/llm/utils/model_features.py
+++ b/openhands/sdk/llm/utils/model_features.py
@@ -138,6 +138,7 @@ SUPPORTS_STOP_WORDS_FALSE_PATTERNS: list[str] = [
     "o1*",
     # grok-4 specific model name (basename)
     "grok-4-0709",
+    "grok-code-fast-1",
     # DeepSeek R1 family
     "deepseek-r1-0528*",
 ]

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -119,6 +119,14 @@ def test_prompt_cache_support(model, expected_cache):
         ("gemini-1.5-pro", True),
         ("llama-3.1-70b", True),
         ("unknown-model", True),  # Most models support stop words
+        # Models that don't support stop words
+        ("o1", False),
+        ("o1-2024-12-17", False),
+        ("grok-4-0709", False),
+        ("grok-code-fast-1", False),
+        ("xai/grok-4-0709", False),
+        ("xai/grok-code-fast-1", False),
+        ("deepseek-r1-0528", False),
     ],
 )
 def test_stop_words_support(model, expected_stop_words):
@@ -237,3 +245,27 @@ def test_model_matches_with_provider_pattern():
     assert model_matches("openai/gpt-4", ["openai/*"])
     assert model_matches("anthropic/claude-3", ["anthropic/claude*"])
     assert not model_matches("openai/gpt-4", ["anthropic/*"])
+
+
+def test_stop_words_grok_provider_prefixed():
+    """Test that grok models don't support stop words with and without provider prefixes."""
+    assert get_features("xai/grok-4-0709").supports_stop_words is False
+    assert get_features("grok-4-0709").supports_stop_words is False
+    assert get_features("xai/grok-code-fast-1").supports_stop_words is False
+    assert get_features("grok-code-fast-1").supports_stop_words is False
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "o1-mini",
+        "o1-2024-12-17",
+        "xai/grok-4-0709",
+        "xai/grok-code-fast-1",
+        "deepseek-r1-0528",
+    ],
+)
+def test_supports_stop_words_false_models(model):
+    """Test models that don't support stop words."""
+    features = get_features(model)
+    assert features.supports_stop_words is False

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -248,7 +248,7 @@ def test_model_matches_with_provider_pattern():
 
 
 def test_stop_words_grok_provider_prefixed():
-    """Test that grok models don't support stop words with and without provider prefixes."""
+    """Test that grok models don't support stop words with and without provider prefixes."""  # noqa: E501
     assert get_features("xai/grok-4-0709").supports_stop_words is False
     assert get_features("grok-4-0709").supports_stop_words is False
     assert get_features("xai/grok-code-fast-1").supports_stop_words is False


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed compatibility issue with the x-ai/grok-code-fast-1 model when used through OpenRouter. Users were experiencing "Client specified an invalid argument: stop" errors because this model doesn't support the stop parameter. The model is now properly configured to work without stop words.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds the `grok-code-fast-1` model to the `SUPPORTS_STOP_WORDS_FALSE_PATTERNS` list in `openhands/sdk/llm/utils/model_features.py`. This prevents the agent-sdk from sending the `stop` parameter to this model, which doesn't support it.

The fix follows the same pattern as the previous fix for `grok-4-0709` and mirrors the changes made to the main OpenHands repository in PR #10867. The model name pattern is added to the list of models that don't support stop words, and comprehensive tests are added to verify the behavior works correctly for both provider-prefixed (`xai/grok-code-fast-1`) and bare (`grok-code-fast-1`) model names.

**Changes Made:**
- Added `grok-code-fast-1` to `SUPPORTS_STOP_WORDS_FALSE_PATTERNS` in `model_features.py`
- Enhanced test coverage in `test_model_features.py` to include:
  - Tests for both `grok-4-0709` and `grok-code-fast-1` models
  - Tests for provider-prefixed (`xai/`) and bare model names
  - Dedicated test functions for grok model stop words behavior

**Testing:**
- All 75 existing tests continue to pass
- New tests specifically verify that grok models return `supports_stop_words=False`
- Tests cover both provider-qualified and bare model names

---
**Link of any specific issues this addresses:**

This change mirrors the fix applied to the main OpenHands repository in PR All-Hands-AI/OpenHands#10867 for issue All-Hands-AI/OpenHands#10729, ensuring consistency between the main OpenHands codebase and the agent-sdk.

**Related:**
- Main OpenHands PR: https://github.com/All-Hands-AI/OpenHands/pull/10867
- Original Issue: https://github.com/All-Hands-AI/OpenHands/issues/10729

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/dbeb54ee4e9747839c370d69b67b2825)