### PR TITLE
Fix switching confirmation mode and approving actions in one step

### DIFF
--- a/openhands/sdk/agent/agent/agent.py
+++ b/openhands/sdk/agent/agent/agent.py
@@ -104,20 +104,18 @@ class Agent(AgentBase):
         state: ConversationState,
         on_event: ConversationCallbackType,
     ) -> None:
-        # If in confirmation mode stored on state, first check if there are any
-        # pending actions (implicit confirmation) and execute them before sampling
-        # a new action.
-        if state.confirmation_mode:
-            pending_actions = get_unmatched_actions(state.events)
-            if pending_actions:
-                logger.info(
-                    "Confirmation mode: Executing %d pending action(s)",
-                    len(pending_actions),
-                )
-                # Note: agent_waiting_for_confirmation flag is cleared by
-                # Conversation class
-                self._execute_actions(state, pending_actions, on_event)
-                return
+        # Check for pending actions (implicit confirmation) and execute them before sampling
+        # new actions.
+        pending_actions = get_unmatched_actions(state.events)
+        if pending_actions:
+            logger.info(
+                "Confirmation mode: Executing %d pending action(s)",
+                len(pending_actions),
+            )
+            # Note: agent_waiting_for_confirmation flag is cleared by
+            # Conversation class
+            self._execute_actions(state, pending_actions, on_event)
+            return
 
         # If a condenser is registered with the agent, we need to give it an
         # opportunity to transform the events. This will either produce a list

--- a/openhands/sdk/agent/agent/agent.py
+++ b/openhands/sdk/agent/agent/agent.py
@@ -104,16 +104,14 @@ class Agent(AgentBase):
         state: ConversationState,
         on_event: ConversationCallbackType,
     ) -> None:
-        # Check for pending actions (implicit confirmation) and execute them before sampling
-        # new actions.
+        # Check for pending actions (implicit confirmation) 
+        # and execute them before sampling new actions.
         pending_actions = get_unmatched_actions(state.events)
         if pending_actions:
             logger.info(
                 "Confirmation mode: Executing %d pending action(s)",
                 len(pending_actions),
             )
-            # Note: agent_waiting_for_confirmation flag is cleared by
-            # Conversation class
             self._execute_actions(state, pending_actions, on_event)
             return
 

--- a/openhands/sdk/agent/agent/agent.py
+++ b/openhands/sdk/agent/agent/agent.py
@@ -104,7 +104,7 @@ class Agent(AgentBase):
         state: ConversationState,
         on_event: ConversationCallbackType,
     ) -> None:
-        # Check for pending actions (implicit confirmation) 
+        # Check for pending actions (implicit confirmation)
         # and execute them before sampling new actions.
         pending_actions = get_unmatched_actions(state.events)
         if pending_actions:


### PR DESCRIPTION
This is to fix the case where the user disables confirmation while simultaneously approving pending actions (https://github.com/All-Hands-AI/OpenHands-CLI/pull/43)

<img width="1848" height="1754" alt="image" src="https://github.com/user-attachments/assets/71c069c4-ca13-44fc-bc53-1ca873d44894" />

As you can see from the image, we want the option to confirm pending actions and always proceed. Always proceeding is the same as disabling confirmation mode. However, this throws the following error.

```
Error starting agent chat: litellm.BadRequestError: AnthropicException - {"type":"error","error":{"type":"invalid_request_error","message":"messages.1: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_017UkRa226LW76DDiHAWKAaY. Each `tool_use` block must have a corresponding `tool_result` block in the next message."},"request_id":"req_011CSwrcFsrGbNzpUi9VKqcA"}
```

Disabling confirmation mode and approving actions simultaneously is problematic, since we only execute pending actions if confirmation mode is enabled. This PR makes it so that pending actions are always executed. 

