### PR TITLE
Clean up metadata: Remove user_id and web_host from LLM metadata

### DIFF
--- a/openhands/sdk/llm/metadata.py
+++ b/openhands/sdk/llm/metadata.py
@@ -1,11 +1,7 @@
-import os
-
-
 def get_llm_metadata(
     model_name: str,
     agent_name: str,
     session_id: str | None = None,
-    user_id: str | None = None,
 ) -> dict:
     import openhands.sdk
 
@@ -22,13 +18,10 @@ def get_llm_metadata(
         "tags": [
             f"model:{model_name}",
             f"agent:{agent_name}",
-            f"web_host:{os.environ.get('WEB_HOST', 'unspecified')}",
             f"openhands_version:{openhands.sdk.__version__}",
             f"openhands_tools_version:{openhands_tools_version}",
         ],
     }
     if session_id is not None:
         metadata["session_id"] = session_id
-    if user_id is not None:
-        metadata["trace_user_id"] = user_id
     return metadata

--- a/tests/sdk/llm/test_get_llm_metadata.py
+++ b/tests/sdk/llm/test_get_llm_metadata.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import patch
 
 
@@ -12,13 +11,12 @@ def test_get_llm_metadata_basic():
     assert "trace_version" in metadata
     assert "tags" in metadata
     assert isinstance(metadata["tags"], list)
-    assert len(metadata["tags"]) == 5
+    assert len(metadata["tags"]) == 4
 
     # Check required tags
     tags = metadata["tags"]
     assert "model:gpt-4o" in tags
     assert "agent:test-agent" in tags
-    assert any(tag.startswith("web_host:") for tag in tags)
     assert any(tag.startswith("openhands_version:") for tag in tags)
     assert any(tag.startswith("openhands_tools_version:") for tag in tags)
 
@@ -66,12 +64,10 @@ def test_get_llm_metadata_none_values():
         model_name="gpt-4o",
         agent_name="test-agent",
         session_id=None,
-        user_id=None,
     )
 
-    # Should not have session_id or trace_user_id keys
+    # Should not have session_id key
     assert "session_id" not in metadata
-    assert "trace_user_id" not in metadata
     assert "trace_version" in metadata
     assert "tags" in metadata
 
@@ -89,19 +85,6 @@ def test_get_llm_metadata_with_session_id():
     assert metadata["session_id"] == "test-session-123"
 
 
-def test_get_llm_metadata_with_user_id():
-    """Test metadata generation with user_id."""
-    from openhands.sdk.llm.metadata import get_llm_metadata
-
-    metadata = get_llm_metadata(
-        model_name="gpt-4o",
-        agent_name="test-agent",
-        user_id="test-user-456",
-    )
-
-    assert metadata["trace_user_id"] == "test-user-456"
-
-
 def test_get_llm_metadata_with_all_params():
     """Test metadata generation with all parameters."""
     from openhands.sdk.llm.metadata import get_llm_metadata
@@ -110,36 +93,8 @@ def test_get_llm_metadata_with_all_params():
         model_name="claude-3-5-sonnet",
         agent_name="coding-agent",
         session_id="session-789",
-        user_id="user-101",
     )
 
     assert metadata["session_id"] == "session-789"
-    assert metadata["trace_user_id"] == "user-101"
     assert "model:claude-3-5-sonnet" in metadata["tags"]
     assert "agent:coding-agent" in metadata["tags"]
-
-
-@patch.dict("os.environ", {"WEB_HOST": "test.example.com"})
-def test_get_llm_metadata_with_web_host_env():
-    """Test metadata generation with WEB_HOST environment variable."""
-    from openhands.sdk.llm.metadata import get_llm_metadata
-
-    metadata = get_llm_metadata(model_name="gpt-4o", agent_name="test-agent")
-
-    tags = metadata["tags"]
-    assert "web_host:test.example.com" in tags
-
-
-@patch.dict("os.environ", {}, clear=True)
-def test_get_llm_metadata_without_web_host_env():
-    """Test metadata generation without WEB_HOST environment variable."""
-    from openhands.sdk.llm.metadata import get_llm_metadata
-
-    # Remove WEB_HOST if it exists
-    if "WEB_HOST" in os.environ:
-        del os.environ["WEB_HOST"]
-
-    metadata = get_llm_metadata(model_name="gpt-4o", agent_name="test-agent")
-
-    tags = metadata["tags"]
-    assert "web_host:unspecified" in tags


### PR DESCRIPTION
## Summary

This PR addresses issue #192 by removing `user_id` and `web_host` from the LLM metadata functionality, as they are application-specific data that fall outside the scope of the SDK.

## Changes Made

### Code Changes
- **Removed `user_id` parameter** from `get_llm_metadata()` function signature
- **Removed `user_id` related logic** (trace_user_id assignment) from the function implementation
- **Removed `web_host` tag** from the metadata tags list
- **Removed unused `os` import** that was only used for web_host functionality

### Test Updates
- Updated basic metadata test to expect 4 tags instead of 5
- Removed web_host assertions from tests
- Removed user_id specific test functions
- Updated test for "all parameters" to only use session_id
- Cleaned up unused imports in test file

## Impact

- **Breaking Change**: The `get_llm_metadata()` function signature has changed - `user_id` parameter is no longer accepted
- **Reduced metadata**: The metadata output now contains 4 tags instead of 5 (removed web_host tag)
- **Cleaner scope**: The SDK now focuses on core functionality without application-specific data

## Testing

- All existing tests have been updated and pass
- Pre-commit hooks (formatting, linting, type checking) pass
- Manual testing confirms the function works correctly with the new signature

## Fixes

Closes #192

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3435e7f928604a438491472ed4a0347b)