### PR TITLE
Fix MistralException for empty assistant messages

### DIFF
--- a/openhands/sdk/llm/message.py
+++ b/openhands/sdk/llm/message.py
@@ -126,6 +126,12 @@ class Message(BaseModel):
         content = "\n".join(
             item.text for item in self.content if isinstance(item, TextContent)
         )
+        
+        # Fix for MistralException: Handle empty assistant messages
+        # If assistant message is empty, provide default message to prevent API errors
+        if self.role == "assistant" and not (content and content.strip()):
+            content = "Task completed."
+        
         message_dict: dict[str, Any] = {"content": content, "role": self.role}
 
         # add tool call keys if we have a tool call or response
@@ -157,6 +163,11 @@ class Message(BaseModel):
                         elem.pop("cache_control", None)
                 content.extend(d_list)
 
+        # Fix for MistralException: Handle empty assistant messages
+        # If assistant message has no content, provide default message to prevent errors
+        if self.role == "assistant" and not content:
+            content = [{"type": "text", "text": "Task completed."}]
+        
         message_dict: dict[str, Any] = {"content": content, "role": self.role}
         if role_tool_with_prompt_caching:
             message_dict["cache_control"] = {"type": "ephemeral"}

--- a/tests/sdk/llm/test_message.py
+++ b/tests/sdk/llm/test_message.py
@@ -230,3 +230,79 @@ def test_text_content_truncation_exact_limit():
 
         # Check that text was not truncated
         assert result["text"] == exact_text
+
+
+def test_empty_assistant_message_string_serializer():
+    """Test that empty assistant messages get default content in string serializer."""
+    from openhands.sdk.llm.message import Message
+
+    # Test with completely empty content
+    message = Message(role="assistant", content=[])
+    result = message.to_llm_dict()
+    
+    assert result["role"] == "assistant"
+    assert result["content"] == "Task completed."
+
+
+def test_empty_assistant_message_list_serializer():
+    """Test that empty assistant messages get default content in list serializer."""
+    from openhands.sdk.llm.message import Message
+
+    # Test with completely empty content, forcing list serializer
+    message = Message(
+        role="assistant", 
+        content=[], 
+        cache_enabled=True  # This forces list serializer
+    )
+    result = message.to_llm_dict()
+    
+    assert result["role"] == "assistant"
+    assert result["content"] == [{"type": "text", "text": "Task completed."}]
+
+
+def test_empty_text_assistant_message_string_serializer():
+    """Test that assistant messages with empty text get default content."""
+    from openhands.sdk.llm.message import Message, TextContent
+
+    # Test with empty text content
+    message = Message(role="assistant", content=[TextContent(text="")])
+    result = message.to_llm_dict()
+    
+    assert result["role"] == "assistant"
+    assert result["content"] == "Task completed."
+
+
+def test_whitespace_assistant_message_string_serializer():
+    """Test that assistant messages with only whitespace get default content."""
+    from openhands.sdk.llm.message import Message, TextContent
+
+    # Test with whitespace-only text content
+    message = Message(role="assistant", content=[TextContent(text="   \n\t  ")])
+    result = message.to_llm_dict()
+    
+    assert result["role"] == "assistant"
+    assert result["content"] == "Task completed."
+
+
+def test_non_empty_assistant_message_unchanged():
+    """Test that non-empty assistant messages are not modified."""
+    from openhands.sdk.llm.message import Message, TextContent
+
+    # Test with actual content
+    message = Message(role="assistant", content=[TextContent(text="Hello world")])
+    result = message.to_llm_dict()
+    
+    assert result["role"] == "assistant"
+    assert result["content"] == "Hello world"
+
+
+def test_empty_user_message_unchanged():
+    """Test that empty user messages are not modified (only assistant gets fix)."""
+    from openhands.sdk.llm.message import Message
+
+    # Test with empty user message
+    message = Message(role="user", content=[])
+    result = message.to_llm_dict()
+    
+    assert result["role"] == "user"
+    assert result["content"] == ""  # Should remain empty for non-assistant roles


### PR DESCRIPTION
## Summary

Port fix from OpenHands v0 to agent-sdk v1 to handle empty assistant messages that cause `MistralException`. When assistant messages have no content or only whitespace, provide default "Task completed." message to prevent API errors.

## Problem

Empty assistant messages in conversation history cause `MistralException` when using Mistral models, as the API doesn't accept messages with empty content.

## Solution

- Modified `Message._string_serializer()` to detect empty assistant content and provide default message
- Modified `Message._list_serializer()` to detect empty assistant content lists and provide default message
- Only affects assistant role messages - other roles (user, system, tool) are unchanged
- Default message: "Task completed." (consistent with OpenHands v0 fix)

## Changes

- **openhands/sdk/llm/message.py**: Added empty content checks in both serialization methods
- **tests/sdk/llm/test_message.py**: Added 6 comprehensive tests covering:
  - Empty content lists
  - Empty text content
  - Whitespace-only text content
  - Non-empty messages remain unchanged
  - Non-assistant roles remain unchanged

## Testing

All tests pass:
- ✅ 18/18 existing tests continue to pass
- ✅ 6/6 new tests for the fix pass
- ✅ Linting passes (ruff)

## Edge Cases Covered

- Empty content list: `[]` → `[{"type": "text", "text": "Task completed."}]`
- Empty text: `[TextContent(text="")]` → `"Task completed."`
- Whitespace only: `[TextContent(text="   \n\t  ")]` → `"Task completed."`
- Non-assistant roles: No changes applied
- Non-empty messages: No changes applied

This fix ensures compatibility with Mistral models while maintaining backward compatibility with all existing functionality.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ff093d03e4a445d7b56402c0ef12629e)