### PR TITLE
fix: prevent data mutation during visualize

### DIFF
--- a/tests/sdk/event/test_system_prompt_event_visualize.py
+++ b/tests/sdk/event/test_system_prompt_event_visualize.py
@@ -1,0 +1,119 @@
+"""Tests for SystemPromptEvent.visualize method."""
+
+import copy
+from typing import Any, Dict, cast
+
+from litellm import ChatCompletionToolParam
+
+from openhands.sdk.event.llm_convertible import SystemPromptEvent
+from openhands.sdk.llm import TextContent
+
+
+def test_visualize_no_data_mutation():
+    """Test that visualize does not mutate the original event data."""
+    # Create tool with long type field (edge case)
+    original_tool: Dict[str, Any] = {
+        "type": "function_with_very_long_type_name_exceeding_thirty_characters",
+        "function": {
+            "name": "test_tool",
+            "description": "Test description",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    event = SystemPromptEvent(
+        system_prompt=TextContent(text="Test system prompt"),
+        tools=[cast(ChatCompletionToolParam, original_tool)],
+    )
+
+    # Store initial state
+    initial_tool_state = copy.deepcopy(event.tools[0])
+
+    # Call visualize multiple times
+    for _ in range(3):
+        _ = event.visualize
+
+    # Verify no mutation occurred
+    assert event.tools[0] == initial_tool_state
+    assert len(event.tools[0]["type"]) == len(initial_tool_state["type"])
+
+
+def test_visualize_parameter_truncation():
+    """Test that long parameter JSON strings are truncated in display."""
+    # Create tool with very long parameters
+    long_params = {
+        "type": "object",
+        "properties": {
+            f"param_{i}": {
+                "type": "string",
+                "description": f"Parameter {i} with very long description",
+            }
+            for i in range(50)
+        },
+        "required": [f"param_{i}" for i in range(25)],
+    }
+
+    tool: Dict[str, Any] = {
+        "type": "function",
+        "function": {
+            "name": "test_tool",
+            "description": "Test tool",
+            "parameters": long_params,
+        },
+    }
+
+    event = SystemPromptEvent(
+        system_prompt=TextContent(text="Test system prompt"),
+        tools=[cast(ChatCompletionToolParam, tool)],
+    )
+
+    # Get visualization
+    visualization = event.visualize
+    visualization_text = visualization.plain
+
+    # Find parameters line
+    params_lines = [
+        line for line in visualization_text.split("\n") if "Parameters:" in line
+    ]
+    assert len(params_lines) == 1
+
+    params_text = params_lines[0].split("Parameters: ")[1]
+
+    # Verify truncation
+    assert len(params_text) <= 200
+    assert params_text.endswith("...")
+
+
+def test_visualize_string_truncation_logic():
+    """Test the string truncation logic for tool fields."""
+    # Create tool with long string fields that would be truncated
+    tool: Dict[str, Any] = {
+        "type": "function_with_very_long_type_name_that_exceeds_thirty_characters",
+        "function": {
+            "name": "test_tool_with_very_long_name_exceeding_limit",
+            "description": "This is a very long description that should be truncated",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    event = SystemPromptEvent(
+        system_prompt=TextContent(text="Test system prompt"),
+        tools=[cast(ChatCompletionToolParam, tool)],
+    )
+
+    # Store original lengths
+    original_type_len = len(tool["type"])
+    original_name_len = len(tool["function"]["name"])  # type: ignore[index]
+    original_desc_len = len(tool["function"]["description"])  # type: ignore[index]
+
+    # Call visualize
+    visualization = event.visualize
+    visualization_text = visualization.plain
+
+    # Verify original data unchanged
+    assert len(event.tools[0]["type"]) == original_type_len
+    assert len(event.tools[0]["function"]["name"]) == original_name_len  # type: ignore[index]
+    assert len(event.tools[0]["function"]["description"]) == original_desc_len  # type: ignore[index]
+
+    # Verify visualization contains truncated display
+    assert "..." in visualization_text  # Some truncation occurred in display


### PR DESCRIPTION
## Problem

The `SystemPromptEvent.visualize` method mutates the event's internal tool data by directly modifying tool dictionaries during string truncation. This causes:

1. **Data corruption**: Event tool data gets permanently truncated after first visualization
2. **Cumulative truncation**: Multiple visualizations progressively shorten already truncated data  
3. **Parameter display issues**: Long parameter JSON strings are not truncated for display

## Solution

- **Prevent mutation**: Create display-only copy (`tool_display`) instead of modifying original data
- **Add parameter truncation**: Limit parameter JSON strings to 200 characters for display
- **Improve type safety**: Add `isinstance()` guard for `tool_fn` dictionary access

## Changes

```python
# Before: Direct mutation
for k, v in tool.items():
    if isinstance(v, str) and len(v) > 30:
        tool[k] = v[:27] + "..."  # Mutates original data

# After: Display-only copy
tool_display = {
    k: (v[:27] + "..." if isinstance(v, str) and len(v) > 30 else v)
    for k, v in tool.items()
}
```

## Testing

- ✅ All existing tests pass (18/18)
- ✅ Verified original tool data remains unchanged after visualization
- ✅ Confirmed parameter truncation works correctly
- ✅ Pre-commit hooks pass (formatting, linting, type checking)

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3ade8c8a8ffb4fa98a3007eefb304ef6)