### PR TITLE
Fix type hints for get_edit_groups to accept optional parameters

### DIFF
--- a/openhands/tools/str_replace_editor/utils/diff.py
+++ b/openhands/tools/str_replace_editor/utils/diff.py
@@ -10,7 +10,7 @@ class EditGroup(BaseModel):
 
 
 def get_edit_groups(
-    old_content: str, new_content: str, n_context_lines: int = 2
+    old_content: str | None, new_content: str | None, n_context_lines: int = 2
 ) -> list[EditGroup]:
     """Get the edit groups showing changes between old and new content.
 

--- a/tests/tools/str_replace_editor/test_visualize_diff.py
+++ b/tests/tools/str_replace_editor/test_visualize_diff.py
@@ -256,13 +256,13 @@ line3"""
 def test_get_edit_groups_no_content():
     """Test get_edit_groups when old_content or new_content is None."""
     # Test with None values directly - should return empty list
-    edit_groups = get_edit_groups(None, "some content")  # type: ignore
+    edit_groups = get_edit_groups(None, "some content")
     assert edit_groups == []
 
-    edit_groups = get_edit_groups("some content", None)  # type: ignore
+    edit_groups = get_edit_groups("some content", None)
     assert edit_groups == []
 
-    edit_groups = get_edit_groups(None, None)  # type: ignore
+    edit_groups = get_edit_groups(None, None)
     assert edit_groups == []
 
     # Test with empty string vs content - should return edit groups


### PR DESCRIPTION
## Summary

Fixes the type hints for the `get_edit_groups` function to properly reflect that it accepts optional `str | None` parameters for both `old_content` and `new_content`.

## Changes

- **Type signature fix**: Changed `old_content: str, new_content: str` to `old_content: str | None, new_content: str | None`
- **Test cleanup**: Removed unnecessary `# type: ignore` comments from tests that were working around the incorrect type hints

## Why this fix is needed

The function already handled `None` values correctly (line 23 has `if old_content is None or new_content is None: return []`), but the type hints were incorrect, forcing callers to use `# type: ignore` comments.

## Testing

- ✅ All existing tests pass
- ✅ Function correctly handles `None` values as before
- ✅ Type checking now passes without `# type: ignore` comments
- ✅ Pre-commit hooks pass (formatting, linting, type checking)

This aligns the type signature with the actual implementation and usage patterns.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d50f453285594883b98cbcfbf27db3e7)