### PR TITLE
Improve error handling in TaskTracker JSON loading

### DIFF
--- a/openhands/tools/task_tracker/definition.py
+++ b/openhands/tools/task_tracker/definition.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 from rich.text import Text
 
 from openhands.sdk import ImageContent, TextContent
@@ -220,7 +220,7 @@ class TaskTrackerExecutor(ToolExecutor):
         try:
             with open(tasks_file, "r", encoding="utf-8") as f:
                 self._task_list = [TaskItem.model_validate(d) for d in json.load(f)]
-        except (OSError, json.JSONDecodeError) as e:
+        except (OSError, json.JSONDecodeError, TypeError, ValidationError) as e:
             logger.warning(
                 f"Failed to load tasks from {tasks_file}: {e}. Starting with "
                 "an empty task list."


### PR DESCRIPTION
## Summary

Improves error handling in the TaskTracker's `_load_tasks` method to be more defensive against malformed JSON.

## Problem Addressed

The original code assumed `json.load(f)` would always return a list, but could fail with:
- **TypeError**: When JSON contains `null`, numbers, strings, or other non-iterable types
- **ValidationError**: When JSON contains a list with invalid task structures

## Testing

Verified the fix handles all these scenarios gracefully:

```python
# Test cases that now work correctly:
test_cases = [
    ('null', 'null'),                                    # TypeError
    ('string', '"not a list"'),                         # ValidationError  
    ('number', '42'),                                    # TypeError
    ('object', '{"not": "a list"}'),                    # ValidationError
    ('invalid_task_structure', '[{"invalid": "structure"}]'), # ValidationError
    ('valid_tasks', '[{"title": "Test Task", "status": "todo"}]') # ✅ Works
]
```

All cases now log appropriate warnings and gracefully fall back to an empty task list instead of crashing.

## CodeRabbit Feedback Addressed

> 🛠️ Refactor suggestion: JSON load path: good switch to model_validate. Add TypeError catch. Defensive against non-list JSON or wrong shapes.

✅ **Implemented**: Added `TypeError` and `ValidationError` to exception handling

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d50f453285594883b98cbcfbf27db3e7)