### PR TITLE
Remove all dim text styling from visualizer

### DIFF
--- a/openhands/sdk/conversation/visualizer.py
+++ b/openhands/sdk/conversation/visualizer.py
@@ -186,7 +186,7 @@ class ConversationVisualizer:
                 content,
                 title=f"[bold {_ERROR_COLOR}]UNKNOWN Event: {event.__class__.__name__}"
                 f"[/bold {_ERROR_COLOR}]",
-                subtitle=f"[dim]({event.source})[/dim]",
+                subtitle=f"({event.source})",
                 border_style=_ERROR_COLOR,
                 padding=_PANEL_PADDING,
                 expand=True,
@@ -237,7 +237,7 @@ class ConversationVisualizer:
         parts.append(f"[blue]↓ output {output_tokens}[/blue]")
         parts.append(f"[green]$ {cost_str}[/green]")
 
-        return "Tokens: " + " [dim]•[/dim] ".join(parts)
+        return "Tokens: " + " • ".join(parts)
 
 
 def create_default_visualizer(


### PR DESCRIPTION
## Summary

This PR fixes issue #242 by removing all "dim" text styling from the conversation visualizer. The dim text styling doesn't look good in many terminals, as shown in the issue screenshot.

## Changes Made

- **Removed dim styling from unknown event subtitle**: Changed `[dim]({event.source})[/dim]` to `({event.source})` in the fallback panel for unknown event types
- **Removed dim styling from metrics bullet separators**: Changed `" [dim]•[/dim] "` to `" • "` in the token metrics subtitle formatting
- **Added comprehensive test**: Created `test_no_dim_styling_in_visualizer()` to verify that no dim styling is used in the visualizer output

## Testing

- All existing tests continue to pass (78 tests in conversation module)
- New test specifically verifies that dim styling has been removed from:
  - Metrics subtitle formatting
  - Unknown event panel subtitles
- Pre-commit hooks pass (formatting, linting, type checking)

## Impact

This change improves the visual appearance of the conversation visualizer across different terminal environments by removing dim text that may be hard to read or invisible in some terminals.

Fixes #242

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ae70ebe609fe42b6b4484526fcbddc23)