### PR TITLE
Fix execute_bash tool to inherit environment variables from parent process

### DIFF
--- a/openhands/tools/execute_bash/terminal/subprocess_terminal.py
+++ b/openhands/tools/execute_bash/terminal/subprocess_terminal.py
@@ -67,6 +67,7 @@ class SubprocessTerminal(TerminalInterface):
         if self._initialized:
             return
 
+        # Inherit environment variables from the parent process
         env = os.environ.copy()
         env["PS1"] = self.PS1
         env["PS2"] = ""

--- a/openhands/tools/execute_bash/terminal/tmux_terminal.py
+++ b/openhands/tools/execute_bash/terminal/tmux_terminal.py
@@ -1,5 +1,6 @@
 """Tmux-based terminal backend implementation."""
 
+import os
 import time
 import uuid
 
@@ -34,6 +35,9 @@ class TmuxTerminal(TerminalInterface):
         if self._initialized:
             return
 
+        # Inherit environment variables from the parent process
+        env = os.environ.copy()
+
         self.server = libtmux.Server()
         _shell_command = "/bin/bash"
         if self.username in ["root", "openhands"]:
@@ -50,6 +54,7 @@ class TmuxTerminal(TerminalInterface):
             kill_session=True,
             x=1000,
             y=1000,
+            environment=env,
         )
 
         # Set history limit to a large number to avoid losing history
@@ -63,6 +68,7 @@ class TmuxTerminal(TerminalInterface):
             window_name="bash",
             window_shell=window_command,
             start_directory=self.work_dir,
+            environment=env,
         )
         self.pane = self.window.active_pane
         assert isinstance(self.pane, libtmux.Pane)

--- a/tests/tools/execute_bash/test_bash_session.py
+++ b/tests/tools/execute_bash/test_bash_session.py
@@ -141,6 +141,43 @@ def test_environment_variable_persistence(terminal_type):
     session.close()
 
 
+@parametrize_terminal_types
+def test_environment_variable_inheritance_from_parent(terminal_type):
+    """Test that environment variables from parent process are inherited."""
+    # Set an environment variable in the current process
+    test_var_name = "OPENHANDS_TEST_INHERITANCE_VAR"
+    test_var_value = "inherited_from_parent_12345"
+    original_value = os.environ.get(test_var_name)
+
+    try:
+        # Set the environment variable in the parent process
+        os.environ[test_var_name] = test_var_value
+
+        # Create a new terminal session
+        session = create_terminal_session(
+            work_dir=os.getcwd(), terminal_type=terminal_type
+        )
+        session.initialize()
+
+        # Check if the environment variable is available in the terminal
+        obs = session.execute(
+            ExecuteBashAction(command=f"echo ${test_var_name}", security_risk="LOW")
+        )
+        assert test_var_value in obs.output, (
+            f"Expected '{test_var_value}' in output, but got: {obs.output}"
+        )
+        assert obs.metadata.exit_code == 0
+
+        session.close()
+
+    finally:
+        # Clean up: restore original environment variable value
+        if original_value is not None:
+            os.environ[test_var_name] = original_value
+        else:
+            os.environ.pop(test_var_name, None)
+
+
 def test_long_running_command_follow_by_execute():
     session = create_terminal_session(work_dir=os.getcwd(), no_change_timeout_seconds=2)
     session.initialize()

--- a/tests/tools/execute_bash/test_bash_session.py
+++ b/tests/tools/execute_bash/test_bash_session.py
@@ -178,50 +178,6 @@ def test_environment_variable_inheritance_from_parent(terminal_type):
             os.environ.pop(test_var_name, None)
 
 
-def test_subprocess_terminal_environment_inheritance():
-    """Test that subprocess terminal specifically inherits environment variables."""
-    # Set an environment variable in the current process
-    test_var_name = "OPENHANDS_SUBPROCESS_TEST_VAR"
-    test_var_value = "subprocess_inherited_value_67890"
-    original_value = os.environ.get(test_var_name)
-
-    try:
-        # Set the environment variable in the parent process
-        os.environ[test_var_name] = test_var_value
-
-        # Create a subprocess terminal session specifically
-        session = create_terminal_session(
-            work_dir=os.getcwd(), terminal_type="subprocess"
-        )
-        session.initialize()
-
-        # Check if the environment variable is available in the subprocess terminal
-        obs = session.execute(
-            ExecuteBashAction(command=f"echo ${test_var_name}", security_risk="LOW")
-        )
-        assert test_var_value in obs.output, (
-            f"Expected '{test_var_value}' in subprocess terminal output, "
-            f"but got: {obs.output}"
-        )
-        assert obs.metadata.exit_code == 0
-
-        # Also test that we can access standard environment variables
-        obs = session.execute(
-            ExecuteBashAction(command="echo $HOME", security_risk="LOW")
-        )
-        assert obs.metadata.exit_code == 0
-        assert len(obs.output.strip()) > 0, "HOME environment variable should be set"
-
-        session.close()
-
-    finally:
-        # Clean up: restore original environment variable value
-        if original_value is not None:
-            os.environ[test_var_name] = original_value
-        else:
-            os.environ.pop(test_var_name, None)
-
-
 def test_long_running_command_follow_by_execute():
     session = create_terminal_session(work_dir=os.getcwd(), no_change_timeout_seconds=2)
     session.initialize()


### PR DESCRIPTION
## Summary

Fixes #243 - `execute_bash` tool should be able to inherit current env vars

## Problem

Previously, when using the `execute_bash` tool, environment variables set in the parent process (e.g., `export A=A`) were not available in the new terminal session. This was because:

1. **TmuxTerminal**: The `new_session()` and `new_window()` calls didn't pass the parent environment variables
2. **SubprocessTerminal**: Already correctly inherited environment variables

## Solution

### Changes Made

1. **Modified TmuxTerminal** (`openhands/tools/execute_bash/terminal/tmux_terminal.py`):
   - Added `import os` to access environment variables
   - Copy parent environment variables using `env = os.environ.copy()`
   - Pass `environment=env` parameter to both `new_session()` and `new_window()` calls

2. **Added comprehensive test** (`tests/tools/execute_bash/test_bash_session.py`):
   - New test `test_environment_variable_inheritance_from_parent()` 
   - Tests both TmuxTerminal and SubprocessTerminal
   - Verifies that environment variables set in the parent process are accessible in the terminal session
   - Includes proper cleanup to avoid test pollution

### Technical Details

The fix leverages the existing `environment` parameter support in the `libtmux` library:
- `libtmux.Server.new_session(environment=env)` 
- `libtmux.Session.new_window(environment=env)`

SubprocessTerminal already correctly inherited environment variables via `subprocess.Popen(env=env)` where `env = os.environ.copy()`.

## Testing

- ✅ New test passes for both terminal types
- ✅ Existing environment variable persistence tests still pass  
- ✅ All execute_bash tests pass
- ✅ Pre-commit hooks pass (formatting, linting, type checking)

## Verification

You can now:
1. Set an environment variable: `export TEST_VAR=hello`
2. Use execute_bash tool: `echo $TEST_VAR` 
3. The variable will be correctly inherited and displayed

This ensures that the execute_bash tool maintains the expected behavior of inheriting the parent process environment, making it more intuitive and consistent with standard shell behavior.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9ecbca3fd05e49f6a003f56c7cd685cb)