### PR TITLE
Add LLM JSON storage functionality

### DIFF
--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -16,7 +16,6 @@ from pydantic import (
     model_validator,
 )
 
-from openhands.sdk.io.base import FileStore
 from openhands.sdk.utils.pydantic_diff import pretty_pydantic_diff
 
 
@@ -709,26 +708,16 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """Serialize the LLM instance to a dictionary."""
         return self.model_dump()
 
-    def store_to_json(
-        self, filestore: FileStore, filepath: str, expose_secrets: bool = False
-    ) -> None:
-        """Store the LLM instance to a JSON file using the provided FileStore.
+    def store_to_json(self, filepath: str) -> None:
+        """Store the LLM instance to a JSON file with secrets exposed.
 
         Args:
-            filestore: FileStore instance to use for writing the file.
             filepath: Path where the JSON file should be stored.
-            expose_secrets: If True, SecretStr fields will be exposed as regular
-                           strings. If False, SecretStr fields will be serialized
-                           as "****".
         """
-        if expose_secrets:
-            # Use model_dump_with_secrets to expose SecretStr values
-            serialized_data = self.model_dump_with_secrets()
-            json_content = json.dumps(serialized_data, indent=2)
-        else:
-            # Use Pydantic's JSON serialization to handle SecretStr properly
-            json_content = self.model_dump_json(indent=2)
-        filestore.write(filepath, json_content)
+        data = self.model_dump_with_secrets()
+
+        with open(filepath, "w") as f:
+            json.dump(data, f, indent=2)
 
     @classmethod
     def load_from_json(cls, json_path: str) -> "LLM":

--- a/tests/sdk/llm/test_llm_json_storage.py
+++ b/tests/sdk/llm/test_llm_json_storage.py
@@ -1,6 +1,5 @@
 """Test LLM JSON storage and loading functionality."""
 
-import json
 import tempfile
 from pathlib import Path
 
@@ -9,8 +8,8 @@ from pydantic import SecretStr
 from openhands.sdk.llm import LLM
 
 
-def test_llm_serialize_and_deserialize_with_secrets():
-    """Test storing LLM to JSON and loading back with secrets exposed."""
+def test_llm_store_and_load_json():
+    """Test storing LLM to JSON and loading back with fields unchanged."""
     # Create original LLM with secrets
     original_llm = LLM(
         model="test-model",
@@ -24,41 +23,13 @@ def test_llm_serialize_and_deserialize_with_secrets():
         num_retries=3,
     )
 
-    # Store to JSON with secrets exposed
+    # Store to JSON and load back
     with tempfile.TemporaryDirectory() as temp_dir:
         filepath = Path(temp_dir) / "test_llm.json"
         original_llm.store_to_json(str(filepath))
+        loaded_llm = LLM.load_from_json(str(filepath))
 
-        # Verify file was created
-        assert filepath.exists()
-
-        # Load back from JSON
-        with open(filepath, "r") as f:
-            loaded_data = json.load(f)
-
-        # Verify basic fields are preserved in JSON
-        assert loaded_data["model"] == "test-model"
-        assert loaded_data["temperature"] == 0.7
-        assert loaded_data["max_output_tokens"] == 2000
-        assert loaded_data["top_p"] == 0.9
-        assert loaded_data["base_url"] == "https://api.example.com"
-        assert loaded_data["num_retries"] == 3
-
-        # Verify secrets are exposed in JSON (not masked)
-        assert loaded_data["api_key"] == "secret-api-key"
-        assert loaded_data["aws_access_key_id"] == "aws-access-key"
-        assert loaded_data["aws_secret_access_key"] == "aws-secret-key"
-
-        # Create LLM from loaded data (need to convert strings back to SecretStr)
-        loaded_data["api_key"] = SecretStr(loaded_data["api_key"])
-        loaded_data["aws_access_key_id"] = SecretStr(loaded_data["aws_access_key_id"])
-        loaded_data["aws_secret_access_key"] = SecretStr(
-            loaded_data["aws_secret_access_key"]
-        )
-
-        loaded_llm = LLM.model_validate(loaded_data)
-
-        # Verify basic fields are preserved in loaded LLM
+        # Verify all fields remain unchanged
         assert loaded_llm.model == original_llm.model
         assert loaded_llm.temperature == original_llm.temperature
         assert loaded_llm.max_output_tokens == original_llm.max_output_tokens
@@ -66,7 +37,7 @@ def test_llm_serialize_and_deserialize_with_secrets():
         assert loaded_llm.base_url == original_llm.base_url
         assert loaded_llm.num_retries == original_llm.num_retries
 
-        # Verify secrets are preserved (same as original values)
+        # Verify secrets are preserved
         assert loaded_llm.api_key is not None
         assert loaded_llm.aws_access_key_id is not None
         assert loaded_llm.aws_secret_access_key is not None

--- a/tests/sdk/llm/test_llm_json_storage.py
+++ b/tests/sdk/llm/test_llm_json_storage.py
@@ -1,15 +1,16 @@
 """Test LLM JSON storage and loading functionality."""
 
 import json
+import tempfile
+from pathlib import Path
 
 from pydantic import SecretStr
 
-from openhands.sdk.io import InMemoryFileStore
 from openhands.sdk.llm import LLM
 
 
 def test_llm_serialize_and_deserialize_with_secrets():
-    """Test storing LLM to JSON and loading it back with secrets."""
+    """Test storing LLM to JSON and loading back with secrets exposed."""
     # Create original LLM with secrets
     original_llm = LLM(
         model="test-model",
@@ -23,44 +24,64 @@ def test_llm_serialize_and_deserialize_with_secrets():
         num_retries=3,
     )
 
-    # Store to JSON without exposing secrets
-    filestore = InMemoryFileStore()
-    filepath = "test_llm.json"
-    original_llm.store_to_json(filestore, filepath, expose_secrets=False)
+    # Store to JSON with secrets exposed
+    with tempfile.TemporaryDirectory() as temp_dir:
+        filepath = Path(temp_dir) / "test_llm.json"
+        original_llm.store_to_json(str(filepath))
 
-    # Load back from JSON
-    stored_content = filestore.read(filepath)
-    loaded_data = json.loads(stored_content)
-    loaded_llm = LLM.model_validate(loaded_data)
+        # Verify file was created
+        assert filepath.exists()
 
-    # Verify basic fields are preserved
-    assert loaded_llm.model == original_llm.model
-    assert loaded_llm.temperature == original_llm.temperature
-    assert loaded_llm.max_output_tokens == original_llm.max_output_tokens
-    assert loaded_llm.top_p == original_llm.top_p
-    assert loaded_llm.base_url == original_llm.base_url
-    assert loaded_llm.num_retries == original_llm.num_retries
+        # Load back from JSON
+        with open(filepath, "r") as f:
+            loaded_data = json.load(f)
 
-    # Verify secrets are masked in the loaded LLM (not the original values)
-    assert loaded_llm.api_key is not None
-    assert loaded_llm.aws_access_key_id is not None
-    assert loaded_llm.aws_secret_access_key is not None
-    assert loaded_llm.api_key.get_secret_value() == "**********"
-    assert loaded_llm.aws_access_key_id.get_secret_value() == "**********"
-    assert loaded_llm.aws_secret_access_key.get_secret_value() == "**********"
+        # Verify basic fields are preserved in JSON
+        assert loaded_data["model"] == "test-model"
+        assert loaded_data["temperature"] == 0.7
+        assert loaded_data["max_output_tokens"] == 2000
+        assert loaded_data["top_p"] == 0.9
+        assert loaded_data["base_url"] == "https://api.example.com"
+        assert loaded_data["num_retries"] == 3
 
-    # Verify they are different from original secret values
-    assert original_llm.api_key is not None
-    assert original_llm.aws_access_key_id is not None
-    assert original_llm.aws_secret_access_key is not None
-    assert (
-        loaded_llm.api_key.get_secret_value() != original_llm.api_key.get_secret_value()
-    )
-    assert (
-        loaded_llm.aws_access_key_id.get_secret_value()
-        != original_llm.aws_access_key_id.get_secret_value()
-    )
-    assert (
-        loaded_llm.aws_secret_access_key.get_secret_value()
-        != original_llm.aws_secret_access_key.get_secret_value()
-    )
+        # Verify secrets are exposed in JSON (not masked)
+        assert loaded_data["api_key"] == "secret-api-key"
+        assert loaded_data["aws_access_key_id"] == "aws-access-key"
+        assert loaded_data["aws_secret_access_key"] == "aws-secret-key"
+
+        # Create LLM from loaded data (need to convert strings back to SecretStr)
+        loaded_data["api_key"] = SecretStr(loaded_data["api_key"])
+        loaded_data["aws_access_key_id"] = SecretStr(loaded_data["aws_access_key_id"])
+        loaded_data["aws_secret_access_key"] = SecretStr(
+            loaded_data["aws_secret_access_key"]
+        )
+
+        loaded_llm = LLM.model_validate(loaded_data)
+
+        # Verify basic fields are preserved in loaded LLM
+        assert loaded_llm.model == original_llm.model
+        assert loaded_llm.temperature == original_llm.temperature
+        assert loaded_llm.max_output_tokens == original_llm.max_output_tokens
+        assert loaded_llm.top_p == original_llm.top_p
+        assert loaded_llm.base_url == original_llm.base_url
+        assert loaded_llm.num_retries == original_llm.num_retries
+
+        # Verify secrets are preserved (same as original values)
+        assert loaded_llm.api_key is not None
+        assert loaded_llm.aws_access_key_id is not None
+        assert loaded_llm.aws_secret_access_key is not None
+        assert original_llm.api_key is not None
+        assert original_llm.aws_access_key_id is not None
+        assert original_llm.aws_secret_access_key is not None
+        assert (
+            loaded_llm.api_key.get_secret_value()
+            == original_llm.api_key.get_secret_value()
+        )
+        assert (
+            loaded_llm.aws_access_key_id.get_secret_value()
+            == original_llm.aws_access_key_id.get_secret_value()
+        )
+        assert (
+            loaded_llm.aws_secret_access_key.get_secret_value()
+            == original_llm.aws_secret_access_key.get_secret_value()
+        )

--- a/tests/sdk/llm/test_llm_json_storage.py
+++ b/tests/sdk/llm/test_llm_json_storage.py
@@ -1,0 +1,66 @@
+"""Test LLM JSON storage and loading functionality."""
+
+import json
+
+from pydantic import SecretStr
+
+from openhands.sdk.io import InMemoryFileStore
+from openhands.sdk.llm import LLM
+
+
+def test_llm_serialize_and_deserialize_with_secrets():
+    """Test storing LLM to JSON and loading it back with secrets."""
+    # Create original LLM with secrets
+    original_llm = LLM(
+        model="test-model",
+        temperature=0.7,
+        max_output_tokens=2000,
+        top_p=0.9,
+        api_key=SecretStr("secret-api-key"),
+        aws_access_key_id=SecretStr("aws-access-key"),
+        aws_secret_access_key=SecretStr("aws-secret-key"),
+        base_url="https://api.example.com",
+        num_retries=3,
+    )
+
+    # Store to JSON without exposing secrets
+    filestore = InMemoryFileStore()
+    filepath = "test_llm.json"
+    original_llm.store_to_json(filestore, filepath, expose_secrets=False)
+
+    # Load back from JSON
+    stored_content = filestore.read(filepath)
+    loaded_data = json.loads(stored_content)
+    loaded_llm = LLM.model_validate(loaded_data)
+
+    # Verify basic fields are preserved
+    assert loaded_llm.model == original_llm.model
+    assert loaded_llm.temperature == original_llm.temperature
+    assert loaded_llm.max_output_tokens == original_llm.max_output_tokens
+    assert loaded_llm.top_p == original_llm.top_p
+    assert loaded_llm.base_url == original_llm.base_url
+    assert loaded_llm.num_retries == original_llm.num_retries
+
+    # Verify secrets are masked in the loaded LLM (not the original values)
+    assert loaded_llm.api_key is not None
+    assert loaded_llm.aws_access_key_id is not None
+    assert loaded_llm.aws_secret_access_key is not None
+    assert loaded_llm.api_key.get_secret_value() == "**********"
+    assert loaded_llm.aws_access_key_id.get_secret_value() == "**********"
+    assert loaded_llm.aws_secret_access_key.get_secret_value() == "**********"
+
+    # Verify they are different from original secret values
+    assert original_llm.api_key is not None
+    assert original_llm.aws_access_key_id is not None
+    assert original_llm.aws_secret_access_key is not None
+    assert (
+        loaded_llm.api_key.get_secret_value() != original_llm.api_key.get_secret_value()
+    )
+    assert (
+        loaded_llm.aws_access_key_id.get_secret_value()
+        != original_llm.aws_access_key_id.get_secret_value()
+    )
+    assert (
+        loaded_llm.aws_secret_access_key.get_secret_value()
+        != original_llm.aws_secret_access_key.get_secret_value()
+    )


### PR DESCRIPTION
Add method to dump LLM to a json 

This ensures that the client doesn't need to understand how `load_from_json` works in order to serialize the LLM. The sdk should just support `LLM.load_from_json(llm.store_to_json())` 