### PR TITLE
Lift ID types in event to type aliases

### DIFF
--- a/openhands/sdk/context/view.py
+++ b/openhands/sdk/context/view.py
@@ -10,7 +10,12 @@ from openhands.sdk.event import (
     Event,
     LLMConvertibleEvent,
 )
-from openhands.sdk.event.llm_convertible import ActionEvent, ObservationEvent
+from openhands.sdk.event.base import EventID
+from openhands.sdk.event.llm_convertible import (
+    ActionEvent,
+    ObservationEvent,
+    ToolCallID,
+)
 from openhands.sdk.utils.protocol import ListLike
 
 
@@ -105,7 +110,7 @@ class View(BaseModel):
         ]
 
     @staticmethod
-    def _get_action_tool_call_ids(events: list[LLMConvertibleEvent]) -> set[str]:
+    def _get_action_tool_call_ids(events: list[LLMConvertibleEvent]) -> set[ToolCallID]:
         """Extract tool_call_ids from ActionEvents."""
         tool_call_ids = set()
         for event in events:
@@ -116,7 +121,7 @@ class View(BaseModel):
     @staticmethod
     def _get_observation_tool_call_ids(
         events: list[LLMConvertibleEvent],
-    ) -> set[str]:
+    ) -> set[ToolCallID]:
         """Extract tool_call_ids from ObservationEvents."""
         tool_call_ids = set()
         for event in events:
@@ -127,8 +132,8 @@ class View(BaseModel):
     @staticmethod
     def _should_keep_event(
         event: LLMConvertibleEvent,
-        action_tool_call_ids: set[str],
-        observation_tool_call_ids: set[str],
+        action_tool_call_ids: set[ToolCallID],
+        observation_tool_call_ids: set[ToolCallID],
     ) -> bool:
         """Determine if an event should be kept based on tool call matching."""
         if isinstance(event, ObservationEvent):
@@ -143,7 +148,7 @@ class View(BaseModel):
         """Create a view from a list of events, respecting the semantics of any
         condensation events.
         """
-        forgotten_event_ids: set[str] = set()
+        forgotten_event_ids: set[EventID] = set()
         condensations: list[Condensation] = []
         for event in events:
             if isinstance(event, Condensation):

--- a/openhands/sdk/conversation/conversation.py
+++ b/openhands/sdk/conversation/conversation.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
 from openhands.sdk.conversation.secrets_manager import SecretValue
 from openhands.sdk.conversation.state import AgentExecutionStatus, ConversationState
-from openhands.sdk.conversation.types import ConversationCallbackType
+from openhands.sdk.conversation.types import ConversationCallbackType, ConversationID
 from openhands.sdk.conversation.visualizer import (
     create_default_visualizer,
 )
@@ -34,10 +34,6 @@ def compose_callbacks(
                 cb(event)
 
     return composed
-
-
-ConversationID = str
-"""Type alias for conversation IDs."""
 
 
 class Conversation:

--- a/openhands/sdk/conversation/conversation.py
+++ b/openhands/sdk/conversation/conversation.py
@@ -36,12 +36,16 @@ def compose_callbacks(
     return composed
 
 
+ConversationID = str
+"""Type alias for conversation IDs."""
+
+
 class Conversation:
     def __init__(
         self,
         agent: "AgentType",
         persist_filestore: FileStore | None = None,
-        conversation_id: str | None = None,
+        conversation_id: ConversationID | None = None,
         callbacks: list[ConversationCallbackType] | None = None,
         max_iteration_per_run: int = 500,
         visualize: bool = True,
@@ -91,7 +95,7 @@ class Conversation:
             self.agent.init_state(self.state, on_event=self._on_event)
 
     @property
-    def id(self) -> str:
+    def id(self) -> ConversationID:
         """Get the unique ID of the conversation."""
         return self.state.id
 

--- a/openhands/sdk/conversation/state.py
+++ b/openhands/sdk/conversation/state.py
@@ -10,6 +10,7 @@ from openhands.sdk.agent.base import AgentType
 from openhands.sdk.conversation.event_store import EventLog
 from openhands.sdk.conversation.persistence_const import BASE_STATE, EVENTS_DIR
 from openhands.sdk.conversation.secrets_manager import SecretsManager
+from openhands.sdk.conversation.types import ConversationID
 from openhands.sdk.event import Event
 from openhands.sdk.io import FileStore, InMemoryFileStore
 from openhands.sdk.logger import get_logger
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
 
 class ConversationState(BaseModel):
     # ===== Public, validated fields =====
-    id: str = Field(description="Unique conversation ID")
+    id: ConversationID = Field(description="Unique conversation ID")
 
     agent: AgentType = Field(
         ...,
@@ -114,7 +115,7 @@ class ConversationState(BaseModel):
     @classmethod
     def create(
         cls: type["ConversationState"],
-        id: str,
+        id: ConversationID,
         agent: AgentType,
         file_store: FileStore | None = None,
     ) -> "ConversationState":

--- a/openhands/sdk/conversation/types.py
+++ b/openhands/sdk/conversation/types.py
@@ -4,3 +4,6 @@ from openhands.sdk.event import Event
 
 
 ConversationCallbackType = Callable[[Event], None]
+
+ConversationID = str
+"""Type alias for conversation IDs."""

--- a/openhands/sdk/event/__init__.py
+++ b/openhands/sdk/event/__init__.py
@@ -13,6 +13,7 @@ from openhands.sdk.event.llm_convertible import (
     UserRejectObservation,
 )
 from openhands.sdk.event.metric_events import EventWithMetrics
+from openhands.sdk.event.types import EventID, ToolCallID
 from openhands.sdk.event.user_action import PauseEvent
 
 
@@ -31,4 +32,6 @@ __all__ = [
     "CondensationRequest",
     "CondensationSummaryEvent",
     "EventWithMetrics",
+    "EventID",
+    "ToolCallID",
 ]

--- a/openhands/sdk/event/base.py
+++ b/openhands/sdk/event/base.py
@@ -19,12 +19,15 @@ if TYPE_CHECKING:
 
 N_CHAR_PREVIEW = 500
 
+EventID = str
+"""Type alias for event IDs."""
+
 
 class EventBase(DiscriminatedUnionMixin, ABC):
     """Base class for all events."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
-    id: str = Field(
+    id: EventID = Field(
         default_factory=lambda: str(uuid.uuid4()),
         description="Unique event id (ULID/UUID)",
     )

--- a/openhands/sdk/event/base.py
+++ b/openhands/sdk/event/base.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Annotated, cast
 from pydantic import ConfigDict, Field
 from rich.text import Text
 
-from openhands.sdk.event.types import SourceType
+from openhands.sdk.event.types import EventID, SourceType
 from openhands.sdk.llm import ImageContent, Message, TextContent
 from openhands.sdk.utils.discriminated_union import (
     DiscriminatedUnionMixin,
@@ -18,9 +18,6 @@ if TYPE_CHECKING:
     from openhands.sdk.event.llm_convertible import ActionEvent
 
 N_CHAR_PREVIEW = 500
-
-EventID = str
-"""Type alias for event IDs."""
 
 
 class EventBase(DiscriminatedUnionMixin, ABC):

--- a/openhands/sdk/event/condenser.py
+++ b/openhands/sdk/event/condenser.py
@@ -1,8 +1,8 @@
 from pydantic import Field
 from rich.text import Text
 
-from openhands.sdk.event.base import EventBase, EventID, LLMConvertibleEvent
-from openhands.sdk.event.types import SourceType
+from openhands.sdk.event.base import EventBase, LLMConvertibleEvent
+from openhands.sdk.event.types import EventID, SourceType
 from openhands.sdk.llm import Message, MetricsSnapshot, TextContent
 
 

--- a/openhands/sdk/event/condenser.py
+++ b/openhands/sdk/event/condenser.py
@@ -1,7 +1,7 @@
 from pydantic import Field
 from rich.text import Text
 
-from openhands.sdk.event.base import EventBase, LLMConvertibleEvent
+from openhands.sdk.event.base import EventBase, EventID, LLMConvertibleEvent
 from openhands.sdk.event.types import SourceType
 from openhands.sdk.llm import Message, MetricsSnapshot, TextContent
 
@@ -9,7 +9,7 @@ from openhands.sdk.llm import Message, MetricsSnapshot, TextContent
 class Condensation(EventBase):
     """This action indicates a condensation of the conversation history is happening."""
 
-    forgotten_event_ids: list[str] = Field(
+    forgotten_event_ids: list[EventID] = Field(
         default_factory=list,
         description="The IDs of the events that are being forgotten "
         "(removed from the `View` given to the LLM).",

--- a/openhands/sdk/event/llm_convertible.py
+++ b/openhands/sdk/event/llm_convertible.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict, Field, computed_field
 from rich.text import Text
 
 from openhands.sdk.event.base import N_CHAR_PREVIEW, EventID, LLMConvertibleEvent
-from openhands.sdk.event.types import SourceType
+from openhands.sdk.event.types import SourceType, ToolCallID
 from openhands.sdk.llm import ImageContent, Message, TextContent, content_to_str
 from openhands.sdk.llm.utils.metrics import MetricsSnapshot
 from openhands.sdk.tool import Action, Observation
@@ -70,10 +70,6 @@ class SystemPromptEvent(LLMConvertibleEvent):
         return (
             f"{base_str}\n  System: {prompt_preview}\n  Tools: {tool_count} available"
         )
-
-
-ToolCallID = str
-"""Type alias for tool call IDs."""
 
 
 class ActionEvent(LLMConvertibleEvent):

--- a/openhands/sdk/event/llm_convertible.py
+++ b/openhands/sdk/event/llm_convertible.py
@@ -6,8 +6,8 @@ from litellm import ChatCompletionMessageToolCall, ChatCompletionToolParam
 from pydantic import ConfigDict, Field, computed_field
 from rich.text import Text
 
-from openhands.sdk.event.base import N_CHAR_PREVIEW, EventID, LLMConvertibleEvent
-from openhands.sdk.event.types import SourceType, ToolCallID
+from openhands.sdk.event.base import N_CHAR_PREVIEW, LLMConvertibleEvent
+from openhands.sdk.event.types import EventID, SourceType, ToolCallID
 from openhands.sdk.llm import ImageContent, Message, TextContent, content_to_str
 from openhands.sdk.llm.utils.metrics import MetricsSnapshot
 from openhands.sdk.tool import Action, Observation

--- a/openhands/sdk/event/llm_convertible.py
+++ b/openhands/sdk/event/llm_convertible.py
@@ -6,7 +6,7 @@ from litellm import ChatCompletionMessageToolCall, ChatCompletionToolParam
 from pydantic import ConfigDict, Field, computed_field
 from rich.text import Text
 
-from openhands.sdk.event.base import N_CHAR_PREVIEW, LLMConvertibleEvent
+from openhands.sdk.event.base import N_CHAR_PREVIEW, EventID, LLMConvertibleEvent
 from openhands.sdk.event.types import SourceType
 from openhands.sdk.llm import ImageContent, Message, TextContent, content_to_str
 from openhands.sdk.llm.utils.metrics import MetricsSnapshot
@@ -72,6 +72,10 @@ class SystemPromptEvent(LLMConvertibleEvent):
         )
 
 
+ToolCallID = str
+"""Type alias for tool call IDs."""
+
+
 class ActionEvent(LLMConvertibleEvent):
     source: SourceType = "agent"
     thought: Sequence[TextContent] = Field(
@@ -83,7 +87,7 @@ class ActionEvent(LLMConvertibleEvent):
     )
     action: Action = Field(..., description="Single action (tool call) returned by LLM")
     tool_name: str = Field(..., description="The name of the tool being called")
-    tool_call_id: str = Field(
+    tool_call_id: ToolCallID = Field(
         ..., description="The unique id returned by LLM API for this tool call"
     )
     tool_call: ChatCompletionMessageToolCall = Field(
@@ -93,7 +97,7 @@ class ActionEvent(LLMConvertibleEvent):
             "so it is easier to construct it into LLM message"
         ),
     )
-    llm_response_id: str = Field(
+    llm_response_id: EventID = Field(
         ...,
         description=(
             "Groups related actions from same LLM response. This helps in tracking "
@@ -160,13 +164,13 @@ class ObservationEvent(LLMConvertibleEvent):
         ..., description="The observation (tool call) sent to LLM"
     )
 
-    action_id: str = Field(
+    action_id: EventID = Field(
         ..., description="The action id that this observation is responding to"
     )
     tool_name: str = Field(
         ..., description="The tool name that this observation is responding to"
     )
-    tool_call_id: str = Field(
+    tool_call_id: ToolCallID = Field(
         ..., description="The tool call id that this observation is responding to"
     )
 
@@ -298,13 +302,13 @@ class UserRejectObservation(LLMConvertibleEvent):
     """Observation when user rejects an action in confirmation mode."""
 
     source: SourceType = "user"
-    action_id: str = Field(
+    action_id: EventID = Field(
         ..., description="The action id that this rejection is responding to"
     )
     tool_name: str = Field(
         ..., description="The tool name that this rejection is responding to"
     )
-    tool_call_id: str = Field(
+    tool_call_id: ToolCallID = Field(
         ..., description="The tool call id that this rejection is responding to"
     )
     rejection_reason: str = Field(

--- a/openhands/sdk/event/types.py
+++ b/openhands/sdk/event/types.py
@@ -3,3 +3,9 @@ from typing import Literal
 
 EventType = Literal["action", "observation", "message", "system_prompt", "agent_error"]
 SourceType = Literal["agent", "user", "environment"]
+
+EventID = str
+"""Type alias for event IDs."""
+
+ToolCallID = str
+"""Type alias for tool call IDs."""


### PR DESCRIPTION
This PR implements the proposal in #206. It also extends the logic to `Conversation` objects and `ConversationID` types, and updates some known references to these types.