### PR TITLE
Fix integration job when run on schedule

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -163,6 +163,7 @@ jobs:
           path: consolidated_report.md
 
       - name: Create consolidated PR comment
+        if: github.event_name == 'pull_request'
         run: |
           COMMENT_BODY=$(cat consolidated_report.md)
           # Use GitHub CLI to create comment


### PR DESCRIPTION
## Summary

This PR fixes issue #298 where the integration workflow was failing when triggered by schedule.

## Problem

The integration workflow (`integration-runner.yml`) was attempting to create PR comments even when triggered by scheduled runs or manual dispatch. Since there's no actual pull request in these cases, the GitHub CLI command `gh pr comment` would fail with:

```
GraphQL: Could not resolve to a PullRequest with the number of 9745. (repository.pullRequest)
```

## Solution

Added a conditional check `if: github.event_name == 'pull_request'` to the "Create consolidated PR comment" step. This ensures that PR comments are only created when the workflow is actually triggered by a pull request event.

## Changes

- Modified `.github/workflows/integration-runner.yml` to conditionally execute the PR comment step only for pull request events
- The consolidated report is still generated and uploaded as an artifact for all trigger types (schedule, manual, PR)
- Only the PR commenting step is skipped for non-PR triggers

## Testing

- Validated YAML syntax
- Verified the conditional logic matches the existing event handling in the workflow

Fixes #298

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fe637e17bd264b89822d71ce66bddedd)