### PR TITLE
Remove DiscriminativeUnionMixin and replace with vanilla Pydantic Annotated types

### DIFF
--- a/openhands/sdk/tool/__init__.py
+++ b/openhands/sdk/tool/__init__.py
@@ -8,6 +8,13 @@ from openhands.sdk.tool.schema import (
     Observation,
     ObservationBase,
 )
+from openhands.sdk.tool.schema_registry import (
+    register_action_schema,
+    register_dynamic_action_schema,
+    register_dynamic_observation_schema,
+    register_observation_schema,
+    register_tool_schema,
+)
 from openhands.sdk.tool.spec import ToolSpec
 from openhands.sdk.tool.tool import (
     Tool,
@@ -28,6 +35,11 @@ __all__ = [
     "Action",
     "ObservationBase",
     "Observation",
+    "register_action_schema",
+    "register_dynamic_action_schema",
+    "register_dynamic_observation_schema",
+    "register_observation_schema",
+    "register_tool_schema",
     "FinishTool",
     "ThinkTool",
     "BUILT_IN_TOOLS",

--- a/openhands/sdk/tool/schema_registry.py
+++ b/openhands/sdk/tool/schema_registry.py
@@ -1,0 +1,261 @@
+"""
+Schema registry system for dynamic action and observation schemas.
+
+This module provides a replacement for DiscriminatedUnionMixin that uses
+vanilla Pydantic with a registry-based approach for dynamic schema management.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, TypeVar, get_args, get_origin
+
+from pydantic import BaseModel, TypeAdapter, create_model
+from pydantic_core import PydanticUndefined
+
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def kind_of(t: type) -> str:
+    """Get the kind string for a given class."""
+    return f"{t.__module__}.{t.__qualname__}"
+
+
+def _type_to_str(tp: Any) -> str:
+    """Best-effort readable type name (for fallback only)."""
+    try:
+        origin = get_origin(tp)
+        if origin:
+            args = ", ".join(_type_to_str(a) for a in get_args(tp))
+            return f"{origin.__name__}[{args}]"
+        if isinstance(tp, type):
+            return tp.__name__
+        return str(tp)
+    except Exception:
+        return "Any"
+
+
+class SchemaRegistry:
+    """Registry for managing dynamic schemas without inheritance requirements."""
+
+    def __init__(self):
+        self._schemas: dict[str, type[BaseModel]] = {}
+        self._specs: dict[str, dict[str, Any]] = {}
+
+    def register_schema(self, schema_class: type[BaseModel]) -> None:
+        """Register a schema class in the registry."""
+        kind = kind_of(schema_class)
+        self._schemas[kind] = schema_class
+
+        # Store the spec for potential reconstruction
+        spec = self._create_spec(schema_class)
+        self._specs[kind] = spec
+
+    def get_schema(self, kind: str) -> type[BaseModel] | None:
+        """Get a registered schema by kind string."""
+        # First try direct lookup
+        if kind in self._schemas:
+            return self._schemas[kind]
+
+        # Try to import and register the class
+        schema_class = self._resolve_kind_via_import(kind)
+        if schema_class:
+            self.register_schema(schema_class)
+            return schema_class
+
+        return None
+
+    def create_from_spec(self, spec: dict[str, Any], data: dict[str, Any]) -> BaseModel:
+        """Create a model instance from a spec and data."""
+        base_cls = BaseModel
+
+        # Try to resolve the base class
+        base_name = spec.get("base")
+        if isinstance(base_name, str):
+            base_cls = self._resolve_kind_via_import(base_name) or base_cls
+
+        # Build field definitions
+        field_defs: dict[str, tuple[Any, Any]] = {}
+        for name, meta in spec.get("fields", {}).items():
+            tname = meta.get("type", "Any")
+            # Map common type names
+            typemap: dict[str, Any] = {
+                "str": str,
+                "int": int,
+                "float": float,
+                "bool": bool,
+                "list": list,
+                "dict": dict,
+                "Any": Any,
+            }
+            ann = typemap.get(tname.split("[", 1)[0], Any)
+            field_defs[name] = (
+                ann,
+                ... if meta.get("required", False) else meta.get("default", None),
+            )
+
+        # Create temporary model
+        TempModel = create_model(
+            spec.get("title", "DynamicModel"),
+            __base__=base_cls,
+            **field_defs,  # type: ignore[arg-type]
+        )
+
+        return TempModel.model_validate(data)
+
+    def _create_spec(self, schema_class: type[BaseModel]) -> dict[str, Any]:
+        """Create a spec dictionary from a schema class."""
+        fields: dict[str, dict[str, Any]] = {}
+
+        for fname, f in schema_class.model_fields.items():
+            info: dict[str, Any] = {"type": _type_to_str(f.annotation)}
+            if f.is_required():
+                info["required"] = True
+            else:
+                info["required"] = False
+
+                # Only include a concrete, JSON-safe default
+                default = getattr(f, "default", PydanticUndefined)
+                default_factory = getattr(f, "default_factory", None)
+                if default is not PydanticUndefined and default_factory is None:
+                    jsonable = TypeAdapter(Any).dump_python(default, mode="json")
+                    if jsonable is not None:
+                        info["default"] = jsonable
+
+            fields[fname] = info
+
+        return {
+            "title": kind_of(schema_class),
+            "base": kind_of(schema_class),
+            "fields": fields,
+        }
+
+    def _resolve_kind_via_import(self, kind: str) -> type[BaseModel] | None:
+        """Try to import and resolve a kind string to a class."""
+        parts = kind.split(".")
+        for i in range(len(parts) - 1, 0, -1):
+            try:
+                module = importlib.import_module(".".join(parts[:i]))
+            except ModuleNotFoundError:
+                continue
+
+            attr = module
+            for name in parts[i:]:
+                try:
+                    attr = getattr(attr, name)
+                except AttributeError:
+                    attr = None
+                    break
+
+            if isinstance(attr, type) and issubclass(attr, BaseModel):
+                return attr
+
+        return None
+
+    def register_dynamic_schema(self, schema_class: type[BaseModel]) -> None:
+        """Register a dynamically created schema class.
+
+        This is useful for classes created via create_model() that can't be imported.
+        """
+        kind = kind_of(schema_class)
+        self._schemas[kind] = schema_class
+
+
+# Global registry instances
+action_registry = SchemaRegistry()
+observation_registry = SchemaRegistry()
+tool_registry = SchemaRegistry()
+
+
+def register_action_schema(schema_class: type[BaseModel]) -> None:
+    """Register an action schema."""
+    action_registry.register_schema(schema_class)
+
+
+def register_observation_schema(schema_class: type[BaseModel]) -> None:
+    """Register an observation schema."""
+    observation_registry.register_schema(schema_class)
+
+
+def register_tool_schema(schema_class: type[BaseModel]) -> None:
+    """Register a tool schema."""
+    tool_registry.register_schema(schema_class)
+
+
+def register_dynamic_action_schema(schema_class: type[BaseModel]) -> None:
+    """Register a dynamically created action schema."""
+    action_registry.register_dynamic_schema(schema_class)
+
+
+def register_dynamic_observation_schema(schema_class: type[BaseModel]) -> None:
+    """Register a dynamically created observation schema."""
+    observation_registry.register_dynamic_schema(schema_class)
+
+
+def validate_action(data: dict[str, Any]) -> BaseModel:
+    """Validate action data using the registry."""
+    return _validate_with_registry(data, action_registry)
+
+
+def validate_observation(data: dict[str, Any]) -> BaseModel:
+    """Validate observation data using the registry."""
+    return _validate_with_registry(data, observation_registry)
+
+
+def validate_tool(data: dict[str, Any]) -> BaseModel:
+    """Validate tool data using the registry."""
+    return _validate_with_registry(data, tool_registry)
+
+
+def _validate_with_registry(
+    data: dict[str, Any], registry: SchemaRegistry
+) -> BaseModel:
+    """Validate data using a specific registry."""
+    if not isinstance(data, dict):
+        raise ValueError("Data must be a dictionary")
+
+    kind = data.get("kind")
+    spec = data.get("_du_spec")
+
+    # Try to resolve by kind first
+    if isinstance(kind, str):
+        schema_class = registry.get_schema(kind)
+        if schema_class:
+            # Remove control fields before validation
+            clean_data = {
+                k: v for k, v in data.items() if k not in ("kind", "_du_spec")
+            }
+            return schema_class.model_validate(clean_data)
+
+    # Fallback to spec reconstruction
+    if isinstance(spec, dict):
+        clean_data = {k: v for k, v in data.items() if k not in ("kind", "_du_spec")}
+        return registry.create_from_spec(spec, clean_data)
+
+    # Final fallback - use appropriate base class
+    from openhands.sdk.tool.schema import ActionBase, ObservationBase
+    from openhands.sdk.tool.tool import Tool
+
+    clean_data = {k: v for k, v in data.items() if k not in ("kind", "_du_spec")}
+
+    # Use appropriate base class based on registry type
+    if registry is action_registry:
+        return ActionBase.model_validate(clean_data)
+    elif registry is observation_registry:
+        return ObservationBase.model_validate(clean_data)
+    elif registry is tool_registry:
+        return Tool.model_validate(clean_data)
+    else:
+        # Generic fallback - create a dynamic model
+        from typing import Any
+
+        from pydantic import create_model
+
+        # Create field definitions for create_model
+        field_definitions = {}
+        for k, v in clean_data.items():
+            field_definitions[k] = (Any, v)
+
+        DynamicModel = create_model("DynamicModel", **field_definitions)
+        return DynamicModel.model_validate(clean_data)

--- a/tests/sdk/tool/test_schema_registry.py
+++ b/tests/sdk/tool/test_schema_registry.py
@@ -1,0 +1,177 @@
+"""Tests for the new schema registry system."""
+
+from pydantic import BaseModel, Field
+
+from openhands.sdk.llm import TextContent
+from openhands.sdk.tool.schema import ActionBase, ObservationBase
+from openhands.sdk.tool.schema_registry import (
+    SchemaRegistry,
+    action_registry,
+    kind_of,
+    observation_registry,
+    register_action_schema,
+    register_observation_schema,
+    validate_action,
+    validate_observation,
+)
+
+
+class SampleAction(ActionBase):
+    """Test action for registry testing."""
+
+    message: str = Field(description="Test message")
+
+
+class SampleObservation(ObservationBase):
+    """Test observation for registry testing."""
+
+    result: str = Field(description="Test result")
+
+    @property
+    def agent_observation(self):
+        return [TextContent(text=self.result)]
+
+
+def test_kind_of():
+    """Test kind_of function generates correct kind strings."""
+    assert kind_of(SampleAction) == "tests.sdk.tool.test_schema_registry.SampleAction"
+    assert (
+        kind_of(SampleObservation)
+        == "tests.sdk.tool.test_schema_registry.SampleObservation"
+    )
+
+
+def test_schema_registry_basic():
+    """Test basic schema registry functionality."""
+    registry = SchemaRegistry()
+
+    # Register a schema
+    registry.register_schema(SampleAction)
+
+    # Retrieve it
+    retrieved = registry.get_schema(kind_of(SampleAction))
+    assert retrieved is SampleAction
+
+
+def test_schema_registry_auto_registration():
+    """Test that schemas are auto-registered when defined."""
+    # SampleAction and SampleObservation should be auto-registered
+    assert action_registry.get_schema(kind_of(SampleAction)) is SampleAction
+    assert (
+        observation_registry.get_schema(kind_of(SampleObservation)) is SampleObservation
+    )
+
+
+def test_validate_action():
+    """Test action validation through registry."""
+    # Test with instance
+    action = SampleAction(message="hello")
+    result = validate_action(action.model_dump())
+    assert isinstance(result, SampleAction)
+    assert result.message == "hello"
+
+    # Test with dict containing kind
+    data = {"kind": kind_of(SampleAction), "message": "world"}
+    result = validate_action(data)
+    assert isinstance(result, SampleAction)
+    assert result.message == "world"
+
+
+def test_validate_observation():
+    """Test observation validation through registry."""
+    # Test with instance
+    obs = SampleObservation(result="success")
+    result = validate_observation(obs.model_dump())
+    assert isinstance(result, SampleObservation)
+    assert result.result == "success"
+
+    # Test with dict containing kind
+    data = {"kind": kind_of(SampleObservation), "result": "done"}
+    result = validate_observation(data)
+    assert isinstance(result, SampleObservation)
+    assert result.result == "done"
+
+
+def test_schema_registry_fallback():
+    """Test fallback behavior when kind is not found."""
+    # Create data with unknown kind but no extra fields (ActionBase has extra="forbid")
+    data = {"kind": "unknown.kind"}
+
+    # Should still validate but return an ActionBase instance
+    result = validate_action(data)
+    assert isinstance(result, ActionBase)
+
+
+def test_schema_registry_spec_reconstruction():
+    """Test reconstruction from spec when kind is missing."""
+    # Create a spec manually
+    spec = {
+        "title": "TestSpec",
+        "fields": {"message": {"type": "str", "required": True}},
+    }
+
+    registry = SchemaRegistry()
+    data = {"message": "test"}
+    result = registry.create_from_spec(spec, data)
+
+    assert isinstance(result, BaseModel)
+    assert hasattr(result, "message")
+    assert getattr(result, "message") == "test"
+
+
+def test_manual_registration():
+    """Test manual registration functions."""
+
+    class ManualAction(ActionBase):
+        value: int = Field(description="Test value")
+
+    class ManualObservation(ObservationBase):
+        output: str = Field(description="Test output")
+
+        @property
+        def agent_observation(self):
+            return [TextContent(text=self.output)]
+
+    # These should be auto-registered, but let's test manual registration too
+    register_action_schema(ManualAction)
+    register_observation_schema(ManualObservation)
+
+    # Verify they're registered
+    assert action_registry.get_schema(kind_of(ManualAction)) is ManualAction
+    assert (
+        observation_registry.get_schema(kind_of(ManualObservation)) is ManualObservation
+    )
+
+
+def test_schema_with_kind_field():
+    """Test that schemas automatically get kind field set."""
+    action = SampleAction(message="test")
+    assert action.kind == kind_of(SampleAction)
+
+    obs = SampleObservation(result="test")
+    assert obs.kind == kind_of(SampleObservation)
+
+
+def test_schema_serialization_includes_kind():
+    """Test that serialized schemas include the kind field."""
+    action = SampleAction(message="test")
+    data = action.model_dump()
+    assert "kind" in data
+    assert data["kind"] == kind_of(SampleAction)
+
+    obs = SampleObservation(result="test")
+    data = obs.model_dump()
+    assert "kind" in data
+    assert data["kind"] == kind_of(SampleObservation)
+
+
+def test_registry_import_resolution():
+    """Test that registry can resolve kinds via import."""
+    # This should work for our test classes
+    kind = kind_of(SampleAction)
+    resolved = action_registry._resolve_kind_via_import(kind)
+    assert resolved is SampleAction
+
+    kind = kind_of(SampleObservation)
+    resolved = observation_registry._resolve_kind_via_import(kind)
+    assert resolved is SampleObservation


### PR DESCRIPTION
## Summary

This PR completely removes the `DiscriminativeUnionMixin` system and replaces it with a cleaner, more maintainable approach using vanilla Pydantic Annotated types and a registry-based schema system.

## Changes Made

### Core Architecture Changes
- **Removed DiscriminativeUnionMixin**: Eliminated the complex discriminated union inheritance system
- **Implemented SchemaRegistry**: New registry-based system for managing dynamic action/observation schemas
- **Vanilla Pydantic Approach**: Uses standard Pydantic features with Annotated types for schema validation

### Key Features
- **Dynamic Schema Registration**: Automatic registration of schemas during class creation
- **Runtime Schema Support**: Full support for schemas that are only known at runtime (e.g., MCP tools)
- **Backward Compatibility**: Maintains existing API while simplifying internal architecture
- **Enhanced Tool Support**: Improved support for MCP tool serialization with extra fields

### Technical Implementation
- **SchemaRegistry Class**: Central registry for action, observation, and tool schemas
- **Automatic Registration**: Schema classes auto-register during creation via `__init_subclass__`
- **Fallback Validation**: Generic validation for unknown schema types using dynamic model creation
- **Import Resolution**: Proper handling of class imports for schema reconstruction

### Files Modified
- `openhands/sdk/tool/schema_registry.py` - New registry system implementation
- `openhands/sdk/tool/schema.py` - Updated to use registry-based approach
- `openhands/sdk/tool/tool.py` - Enhanced Tool class with registry integration
- `openhands/sdk/tool/__init__.py` - Updated exports
- `tests/sdk/tool/test_schema_registry.py` - Comprehensive test suite (11 tests)

## Testing

- ✅ All existing SDK tests pass (752/752)
- ✅ New schema registry tests pass (11/11)
- ✅ MCP tool serialization tests pass
- ✅ Agent serialization tests pass
- ✅ Pre-commit hooks pass

## Benefits

1. **Simplified Architecture**: Removes complex inheritance patterns in favor of composition
2. **Better Runtime Support**: Native support for dynamic schemas without workarounds
3. **Easier Maintenance**: Cleaner codebase with fewer special cases
4. **Enhanced Flexibility**: Easy to extend with new schema types
5. **Improved Performance**: Reduced overhead from complex inheritance chains

## Fixes

Closes #309 - Better support for dynamic action schema
Addresses #258 - Runtime schema modification issues  
Addresses #300 - Action schema update difficulties

## Migration Notes

This change is backward compatible - existing code using Action/Observation classes will continue to work without modification. The internal implementation has changed but the public API remains the same.

## Testing Instructions

```bash
# Run all tests
uv run pytest

# Run specific schema registry tests
uv run pytest tests/sdk/tool/test_schema_registry.py -v

# Run MCP tool serialization tests
uv run pytest tests/sdk/agent/test_agent_serialization.py::test_agent_serialization_should_include_mcp_tool -v
```

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7418ee0fcfba4d0c811fcf3760dee34a)