### PR TITLE
Fix DiscriminatedUnionMixin serialization with TypeAdapter

### DIFF
--- a/tests/sdk/io/test_serialization.py
+++ b/tests/sdk/io/test_serialization.py
@@ -1,28 +1,23 @@
-
-
-
 from pydantic import TypeAdapter
+
 from openhands.sdk.event.base import EventBase
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.llm.message import Message, TextContent
 
 
 def test_message_event_serialization_round_trip():
-    """ 
+    """
     Test the ability to serialize MessageEvents using a BaseEvent type adapter and
     then deserialize the result
     """
     # Construct a message event
     text_content = TextContent(text="Hello, world!")
     message = Message(role="user", content=[text_content])
-    original_message_event = MessageEvent(
-        source="user",
-        llm_message=message
-    )
+    original_message_event = MessageEvent(source="user", llm_message=message)
 
     #
     dumped_data = original_message_event.model_dump()
-    
+
     type_adapter = TypeAdapter(EventBase)
     dumped_data = type_adapter.dump_python(original_message_event)
 

--- a/tests/sdk/io/test_serialization.py
+++ b/tests/sdk/io/test_serialization.py
@@ -1,0 +1,31 @@
+
+
+
+from pydantic import TypeAdapter
+from openhands.sdk.event.base import EventBase
+from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.llm.message import Message, TextContent
+
+
+def test_message_event_serialization_round_trip():
+    """ 
+    Test the ability to serialize MessageEvents using a BaseEvent type adapter and
+    then deserialize the result
+    """
+    # Construct a message event
+    text_content = TextContent(text="Hello, world!")
+    message = Message(role="user", content=[text_content])
+    original_message_event = MessageEvent(
+        source="user",
+        llm_message=message
+    )
+
+    #
+    dumped_data = original_message_event.model_dump()
+    
+    type_adapter = TypeAdapter(EventBase)
+    dumped_data = type_adapter.dump_python(original_message_event)
+
+    validated_result = EventBase.model_validate(dumped_data)
+
+    assert validated_result == original_message_event


### PR DESCRIPTION
## Problem

The `DiscriminatedUnionMixin` had a serialization issue when used with `TypeAdapter.dump_python()` (which FastAPI uses internally). The `TypeAdapter` was not properly serializing all fields, specifically missing computed fields like `llm_message` and `kind`, causing the test `test_message_event_serialization_round_trip` to fail.

## Root Cause

`TypeAdapter.dump_python()` uses Pydantic's internal serialization system and doesn't automatically call the instance's `model_dump()` method. While the existing `model_dump()` method worked fine for direct calls, `TypeAdapter` was bypassing it and using Pydantic's default serialization logic.

## Solution

This PR implements two complementary fixes:

1. **Added `@model_serializer` decorator**: This is the key fix that tells Pydantic's serialization system (including `TypeAdapter`) to use our custom serialization method. This ensures all fields (regular and computed) are properly included in serialized output.

2. **Enhanced `model_dump()` method**: Updated the method signature to properly match Pydantic's `BaseModel.model_dump()` interface with correct parameter types and defaults.

## Technical Details

- The `@model_serializer` method iterates through both `model_fields` and `model_computed_fields` to ensure all fields are included
- Fixed deprecation warnings by using class attributes instead of instance attributes  
- Proper type annotations to match Pydantic's interface
- Both approaches work together: `model_dump()` for direct calls and `@model_serializer` for internal Pydantic serialization

## Testing

- ✅ The originally failing test `test_message_event_serialization_round_trip` now passes
- ✅ All existing discriminated union tests continue to pass (13/13)
- ✅ All event serialization tests pass (33/33)
- ✅ All I/O tests pass (6/6)
- ✅ Pre-commit hooks (formatting, linting, type checking) all pass
- ✅ Verified that `TypeAdapter.dump_python()` and `model_dump()` now produce identical results

## Impact

This fix ensures that discriminated union objects work correctly with:
- FastAPI (which uses `TypeAdapter` internally)
- Other tools that use `TypeAdapter` for serialization
- Maintains full backward compatibility with existing code

## Files Changed

- `openhands/sdk/utils/discriminated_union.py`: Added `@model_serializer` decorator and enhanced `model_dump()` method

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/25a3465af8d94d98a6a2656da4aa3ba5)