### PR TITLE
Fix yellow text visibility in visualizer with color theme support

### DIFF
--- a/examples/17_color_themes.py
+++ b/examples/17_color_themes.py
@@ -1,0 +1,81 @@
+"""Example demonstrating color theme customization in the visualizer.
+
+This example shows how to use different color themes to improve readability
+on different terminal backgrounds (light vs dark).
+"""
+
+
+def demo_color_themes():
+    """Demonstrate different color themes for the visualizer."""
+    print("=== Color Theme Examples ===\n")
+
+    # Example 1: Default theme (optimized for both light and dark backgrounds)
+    print("1. Default Theme (balanced for light and dark backgrounds):")
+    print("   - Uses bright_cyan instead of yellow for better readability")
+    print("   - Uses bright_magenta instead of bright_yellow for pause events")
+    print("   - Maintains good contrast on most terminal themes\n")
+
+    # Example 2: Light theme
+    print("2. Light Theme (optimized for light backgrounds):")
+    print("   - Uses darker colors that stand out on white/light backgrounds")
+    print("   - Example: observation='blue', message_user='dark_orange'")
+    print("   Usage:")
+    print("   conversation = Conversation(")
+    print("       agent=agent,")
+    print("       visualize=True,")
+    print("       color_theme=LIGHT_THEME")
+    print("   )\n")
+
+    # Example 3: Dark theme
+    print("3. Dark Theme (similar to original, optimized for dark backgrounds):")
+    print("   - Uses bright colors that stand out on dark backgrounds")
+    print("   - Example: observation='yellow', pause='bright_yellow'")
+    print("   Usage:")
+    print("   conversation = Conversation(")
+    print("       agent=agent,")
+    print("       visualize=True,")
+    print("       color_theme=DARK_THEME")
+    print("   )\n")
+
+    # Example 4: High contrast theme
+    print("4. High Contrast Theme (for accessibility):")
+    print("   - Uses very bright colors for maximum contrast")
+    print("   - Example: observation='bright_white', error='bright_red'")
+    print("   Usage:")
+    print("   conversation = Conversation(")
+    print("       agent=agent,")
+    print("       visualize=True,")
+    print("       color_theme=HIGH_CONTRAST_THEME")
+    print("   )\n")
+
+    # Example 5: Custom theme
+    print("5. Custom Theme (define your own colors):")
+    print("   custom_theme = {")
+    print("       'observation': 'orange',")
+    print("       'pause': 'cyan',")
+    print("       'error': 'bright_red',")
+    print("       'action': 'green',")
+    print("   }")
+    print("   conversation = Conversation(")
+    print("       agent=agent,")
+    print("       visualize=True,")
+    print("       color_theme=custom_theme")
+    print("   )\n")
+
+    print("Available color roles for customization:")
+    print("- observation: Tool output and observation events")
+    print("- message_user: User messages")
+    print("- pause: Pause events")
+    print("- system: System prompts and condensation events")
+    print("- thought: Thought text in highlighting")
+    print("- error: Error events and unknown event types")
+    print("- action: Agent actions")
+    print("- message_assistant: Assistant messages")
+    print("- metrics_reasoning: Reasoning tokens in metrics display")
+
+    print("\nNote: The default theme now uses better colors that work well")
+    print("on both light and dark backgrounds, solving the yellow visibility issue!")
+
+
+if __name__ == "__main__":
+    demo_color_themes()

--- a/openhands/sdk/conversation/__init__.py
+++ b/openhands/sdk/conversation/__init__.py
@@ -3,7 +3,12 @@ from openhands.sdk.conversation.event_store import EventLog, ListLike
 from openhands.sdk.conversation.secrets_manager import SecretsManager
 from openhands.sdk.conversation.state import ConversationState
 from openhands.sdk.conversation.types import ConversationCallbackType
-from openhands.sdk.conversation.visualizer import ConversationVisualizer
+from openhands.sdk.conversation.visualizer import (
+    DARK_THEME,
+    HIGH_CONTRAST_THEME,
+    LIGHT_THEME,
+    ConversationVisualizer,
+)
 
 
 __all__ = [
@@ -11,6 +16,9 @@ __all__ = [
     "ConversationState",
     "ConversationCallbackType",
     "ConversationVisualizer",
+    "LIGHT_THEME",
+    "DARK_THEME",
+    "HIGH_CONTRAST_THEME",
     "SecretsManager",
     "EventLog",
     "ListLike",


### PR DESCRIPTION
## Problem

The OpenHands CLI visualizer used yellow colors (`yellow` and `bright_yellow`) that were difficult to read on white/light terminal backgrounds, as reported by users. This created accessibility issues for users with light-themed terminals.

## Solution

This PR introduces a comprehensive color theming system that:

1. **Fixes the immediate visibility issue** by replacing problematic yellow colors with `bright_cyan` in the default theme
2. **Adds flexible color theming** to support different terminal backgrounds
3. **Maintains full backward compatibility** with existing code

## Changes Made

### 🎨 Improved Default Colors
- `observation`: `yellow` → `bright_cyan` (better contrast on both light and dark backgrounds)
- `pause`: `bright_yellow` → `bright_magenta` (better contrast on both light and dark backgrounds)  
- `metrics_reasoning`: `yellow` → `bright_cyan` (consistent with observation color)

### 🛠️ Color Theme System
- Added `color_theme` parameter to `ConversationVisualizer`
- Support for custom color themes via dictionary
- All panel creation methods now use theme colors instead of hardcoded constants

### 📋 Predefined Themes
- **`LIGHT_THEME`**: Optimized for light/white backgrounds (uses darker colors)
- **`DARK_THEME`**: Similar to original, optimized for dark backgrounds (preserves bright colors)
- **`HIGH_CONTRAST_THEME`**: For accessibility (uses very bright colors)

### 🔧 Usage Examples

```python
# Default (improved) theme - works well on both light and dark backgrounds
conversation = Conversation(agent=agent, visualize=True)

# Light theme for white/light terminal backgrounds
from openhands.sdk.conversation import LIGHT_THEME
conversation = Conversation(agent=agent, visualize=True, color_theme=LIGHT_THEME)

# Custom theme
custom_theme = {"observation": "orange", "pause": "cyan", "error": "bright_red"}
conversation = Conversation(agent=agent, visualize=True, color_theme=custom_theme)
```

## Testing

- ✅ Added comprehensive tests for color theming functionality
- ✅ All existing tests pass (no regressions)
- ✅ Tests cover custom themes, predefined themes, and panel creation
- ✅ Pre-commit hooks pass (formatting, linting, type checking)

## Files Modified

- `openhands/sdk/conversation/visualizer.py`: Main implementation
- `openhands/sdk/conversation/__init__.py`: Export new themes  
- `tests/sdk/conversation/test_visualizer.py`: Added comprehensive tests
- `examples/17_color_themes.py`: Usage examples and documentation

## Backward Compatibility

✅ **Fully backward compatible** - all existing code continues to work without changes. The improved default colors are automatically applied.

## Available Color Roles

Users can customize any of these color roles:
- `observation`: Tool output and observation events
- `message_user`: User messages  
- `pause`: Pause events
- `system`: System prompts and condensation events
- `thought`: Thought text in highlighting
- `error`: Error events and unknown event types
- `action`: Agent actions
- `message_assistant`: Assistant messages
- `metrics_reasoning`: Reasoning tokens in metrics display

This change resolves the yellow text visibility issue while providing a flexible foundation for users with different terminal preferences and accessibility needs.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f7e0a47ea0734920b45ff9abcfcd884b)