### PR TITLE
Add send_text helper method to Conversation class

### DIFF
--- a/openhands/sdk/conversation/conversation.py
+++ b/openhands/sdk/conversation/conversation.py
@@ -139,6 +139,17 @@ class Conversation:
             )
             self._on_event(user_msg_event)
 
+    def send_text(self, text: str) -> None:
+        """Send a text message to the agent.
+
+        This is a convenience method that wraps send_message for simple text input.
+
+        Args:
+            text: The text message to send to the agent
+        """
+        message = Message(role="user", content=[TextContent(text=text)])
+        self.send_message(message)
+
     def run(self) -> None:
         """Runs the conversation until the agent finishes.
 

--- a/tests/sdk/conversation/test_send_text.py
+++ b/tests/sdk/conversation/test_send_text.py
@@ -1,0 +1,126 @@
+from pydantic import SecretStr
+
+from openhands.sdk.agent.base import AgentBase
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.state import ConversationState
+from openhands.sdk.conversation.types import ConversationCallbackType
+from openhands.sdk.event.llm_convertible import MessageEvent, SystemPromptEvent
+from openhands.sdk.llm import LLM, Message, TextContent
+
+
+class DummyAgent(AgentBase):
+    def __init__(self):
+        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        super().__init__(llm=llm, tools=[])
+
+    def init_state(
+        self, state: ConversationState, on_event: ConversationCallbackType
+    ) -> None:
+        event = SystemPromptEvent(
+            source="agent", system_prompt=TextContent(text="dummy"), tools=[]
+        )
+        on_event(event)
+
+    def step(
+        self, state: ConversationState, on_event: ConversationCallbackType
+    ) -> None:
+        on_event(
+            MessageEvent(
+                source="agent",
+                llm_message=Message(role="assistant", content=[TextContent(text="ok")]),
+            )
+        )
+
+
+def test_send_text_creates_correct_message():
+    """Test that send_text creates the correct Message structure."""
+    agent = DummyAgent()
+    conversation = Conversation(agent=agent)
+
+    test_text = "Hello, world!"
+    conversation.send_text(test_text)
+
+    # Should have system prompt + user message
+    assert len(conversation.state.events) == 2
+
+    # Check the user message event
+    user_event = conversation.state.events[-1]
+    assert isinstance(user_event, MessageEvent)
+    assert user_event.source == "user"
+
+    # Check the message structure
+    message = user_event.llm_message
+    assert message.role == "user"
+    assert len(message.content) == 1
+    assert isinstance(message.content[0], TextContent)
+    assert message.content[0].text == test_text
+
+
+def test_send_text_equivalent_to_send_message():
+    """Test that send_text produces the same result as send_message with equivalent Message."""  # noqa: E501
+    agent1 = DummyAgent()
+    agent2 = DummyAgent()
+
+    conversation1 = Conversation(agent=agent1)
+    conversation2 = Conversation(agent=agent2)
+
+    test_text = "Test message"
+
+    # Use send_text
+    conversation1.send_text(test_text)
+
+    # Use send_message with equivalent Message
+    message = Message(role="user", content=[TextContent(text=test_text)])
+    conversation2.send_message(message)
+
+    # Both should have the same number of events
+    assert len(conversation1.state.events) == len(conversation2.state.events)
+
+    # The user message events should be equivalent
+    user_event1 = conversation1.state.events[-1]
+    user_event2 = conversation2.state.events[-1]
+
+    assert isinstance(user_event1, MessageEvent)
+    assert isinstance(user_event2, MessageEvent)
+
+    assert user_event1.source == user_event2.source
+    assert user_event1.llm_message.role == user_event2.llm_message.role
+    assert isinstance(user_event1.llm_message.content[0], TextContent)
+    assert isinstance(user_event2.llm_message.content[0], TextContent)
+    assert (
+        user_event1.llm_message.content[0].text
+        == user_event2.llm_message.content[0].text
+    )
+
+
+def test_send_text_with_empty_string():
+    """Test that send_text works with empty string."""
+    agent = DummyAgent()
+    conversation = Conversation(agent=agent)
+
+    conversation.send_text("")
+
+    # Should have system prompt + user message
+    assert len(conversation.state.events) == 2
+
+    user_event = conversation.state.events[-1]
+    assert isinstance(user_event, MessageEvent)
+    assert isinstance(user_event.llm_message.content[0], TextContent)
+    assert user_event.llm_message.content[0].text == ""
+
+
+def test_send_text_with_multiline_string():
+    """Test that send_text works with multiline strings."""
+    agent = DummyAgent()
+    conversation = Conversation(agent=agent)
+
+    test_text = "Line 1\nLine 2\nLine 3"
+    conversation.send_text(test_text)
+
+    # Should have system prompt + user message
+    assert len(conversation.state.events) == 2
+
+    user_event = conversation.state.events[-1]
+    assert isinstance(user_event, MessageEvent)
+    assert isinstance(user_event.llm_message.content[0], TextContent)
+    assert user_event.llm_message.content[0].text == test_text


### PR DESCRIPTION
## Summary

This PR adds a convenience method `send_text()` to the `Conversation` class that simplifies sending text messages to the agent.

## Changes

- **Added `send_text(text: str)` method** to `Conversation` class in `openhands/sdk/conversation/conversation.py`
- **Added comprehensive tests** in `tests/sdk/conversation/test_send_text.py`

## Benefits

- **Simplicity**: Reduces verbose code by ~75% for simple text messages
- **Backward Compatibility**: Doesn't change any existing functionality  
- **User Experience**: Makes the SDK more approachable for simple use cases

## Before vs After

**Before (using `send_message`):**
```python
conversation.send_message(
    message=Message(
        role="user",
        content=[TextContent(text="Hello world")]
    )
)
```

**After (using `send_text`):**
```python
conversation.send_text("Hello world")
```

## Implementation Details

The `send_text` method:
- Takes a simple `str` parameter
- Creates a `Message` object with `role="user"` and a single `TextContent` containing the text
- Calls the existing `send_message` method
- Produces identical results to equivalent `send_message` calls

## Testing

- Added 4 comprehensive test functions covering:
  - Correct message structure creation
  - Equivalence with `send_message`
  - Edge cases (empty strings, multiline strings)
- All tests pass
- All existing tests continue to pass
- Code follows project style guidelines (passes pre-commit hooks)

This addresses the need for a simpler API while maintaining full backward compatibility and following the project's engineering principles of simplicity and pragmatic problem-solving.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9a59fb0029504e09805ec1fcaa755a5f)