### PR TITLE
Add comprehensive logging for MCP server connections and tool execution

### DIFF
--- a/openhands/sdk/mcp/client.py
+++ b/openhands/sdk/mcp/client.py
@@ -6,7 +6,11 @@ from typing import Any, Callable
 
 from fastmcp import Client as AsyncMCPClient
 
+from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.async_executor import AsyncExecutor
+
+
+logger = get_logger(__name__)
 
 
 class MCPClient(AsyncMCPClient):
@@ -18,6 +22,7 @@ class MCPClient(AsyncMCPClient):
     """
 
     def __init__(self, *args, **kwargs):
+        logger.info(f"Initializing MCP client with args: {args}, kwargs: {kwargs}")
         super().__init__(*args, **kwargs)
         self._executor = AsyncExecutor()
 


### PR DESCRIPTION
Recently users have been experiencing MCP connection issues. These logs will help diagnose MCP connection issues like the one reported where tools appear available but fail with 'Network request failed' errors.

- Log MCP client initialization with config details
- Add detailed logging for connection attempts and failures
- Log tool listing process with server response details
- Add timeout and connection error handling with specific error messages
- Log each step of tool execution including arguments and results
- Distinguish between timeout, connection, and unexpected errors
- Add debug logging for tool creation and wrapper initialization

