### PR TITLE
Replaces confirmation mode with confirmation policy

### DIFF
--- a/openhands/agent_server/event_service.py
+++ b/openhands/agent_server/event_service.py
@@ -179,7 +179,7 @@ class EventService:
         )
 
         # Set confirmation mode if enabled
-        conversation.set_confirmation_mode(self.stored.confirmation_mode)
+        conversation.set_confirmation_policy(self.stored.confirmation_policy)
         self._conversation = conversation
 
     async def run(self):

--- a/openhands/agent_server/models.py
+++ b/openhands/agent_server/models.py
@@ -18,6 +18,7 @@ from openhands.sdk import (
 )
 from openhands.sdk.conversation.state import AgentExecutionStatus
 from openhands.sdk.llm.utils.metrics import MetricsSnapshot
+from openhands.sdk.security.confirmation_policy import ConfirmationPolicy, NeverConfirm
 
 
 # Give pydantic / fastapi some help when serializing
@@ -69,10 +70,10 @@ class StartConversationRequest(AgentSpec):
     """
 
     # These are two conversation specific fields
-    confirmation_mode: bool = Field(
-        default=False,
-        description="If true, the agent will enter confirmation mode, "
-        "requiring user approval for actions.",
+    confirmation_policy: ConfirmationPolicy = Field(
+        default=NeverConfirm(),
+        description="Controls when the conversation will prompt the user before "
+        "continuing. Defaults to never.",
     )
     initial_message: SendMessageRequest | None = Field(
         default=None, description="Initial message to pass to the LLM"

--- a/openhands/sdk/agent/agent.py
+++ b/openhands/sdk/agent/agent.py
@@ -29,6 +29,7 @@ from openhands.sdk.llm import (
     get_llm_metadata,
 )
 from openhands.sdk.logger import get_logger
+from openhands.sdk.security.risk import SecurityRisk
 from openhands.sdk.tool import (
     BUILT_IN_TOOLS,
     ActionBase,
@@ -315,26 +316,24 @@ class Agent(AgentBase):
         if len(action_events) == 0:
             return False
 
-        # If a security analyzer is registered, use it to check the action events and
-        # see if confirmation is needed.
+        # If a security analyzer is registered, use it to grab the risks of the actions
+        # involved. If not, we'll set the risks to UNKNOWN.
         if self.security_analyzer is not None:
-            risks = self.security_analyzer.analyze_pending_actions(action_events)
-            for _, risk in risks:
-                if self.security_analyzer.should_require_confirmation(
-                    risk, state.confirmation_mode
-                ):
-                    state.agent_status = AgentExecutionStatus.WAITING_FOR_CONFIRMATION
-                    return True
-            # If the security analyzer doesn't tell us to stop, we shouldn't stop, even
-            # if the confirmation mode is on.
-            return False
+            risks = [
+                risk
+                for _, risk in self.security_analyzer.analyze_pending_actions(
+                    action_events
+                )
+            ]
+        else:
+            risks = [SecurityRisk.UNKNOWN] * len(action_events)
 
-        # If confirmation mode is disabled, no confirmation is needed
-        if not state.confirmation_mode:
-            return False
+        # Grab the confirmation policy from the state and pass in the risks.
+        if any(state.confirmation_policy.should_confirm(risk) for risk in risks):
+            state.agent_status = AgentExecutionStatus.WAITING_FOR_CONFIRMATION
+            return True
 
-        state.agent_status = AgentExecutionStatus.WAITING_FOR_CONFIRMATION
-        return True
+        return False
 
     def _get_action_events(
         self,

--- a/openhands/sdk/conversation/conversation.py
+++ b/openhands/sdk/conversation/conversation.py
@@ -1,6 +1,8 @@
 import uuid
 from typing import TYPE_CHECKING, Iterable
 
+from openhands.sdk.security.confirmation_policy import ConfirmationPolicy
+
 
 if TYPE_CHECKING:
     from openhands.sdk.agent import AgentType
@@ -192,11 +194,11 @@ class Conversation:
             if iteration >= self.max_iteration_per_run:
                 break
 
-    def set_confirmation_mode(self, enabled: bool) -> None:
+    def set_confirmation_mode(self, policy: ConfirmationPolicy) -> None:
         """Enable or disable confirmation mode and store it in conversation state."""
         with self.state:
-            self.state.confirmation_mode = enabled
-        logger.info(f"Confirmation mode {'enabled' if enabled else 'disabled'}")
+            self.state.confirmation_policy = policy
+        logger.info(f"Confirmation mode set to: {policy}")
 
     def reject_pending_actions(self, reason: str = "User rejected the action") -> None:
         """Reject all pending actions from the agent.

--- a/openhands/sdk/conversation/conversation.py
+++ b/openhands/sdk/conversation/conversation.py
@@ -1,7 +1,11 @@
 import uuid
 from typing import TYPE_CHECKING, Iterable
 
-from openhands.sdk.security.confirmation_policy import ConfirmationPolicy
+from openhands.sdk.security.confirmation_policy import (
+    AlwaysConfirm,
+    ConfirmationPolicy,
+    NeverConfirm,
+)
 
 
 if TYPE_CHECKING:
@@ -194,11 +198,27 @@ class Conversation:
             if iteration >= self.max_iteration_per_run:
                 break
 
-    def set_confirmation_mode(self, policy: ConfirmationPolicy) -> None:
-        """Enable or disable confirmation mode and store it in conversation state."""
+    def set_confirmation_policy(self, policy: ConfirmationPolicy) -> None:
+        """Set the confirmation policy and store it in conversation state."""
         with self.state:
             self.state.confirmation_policy = policy
-        logger.info(f"Confirmation mode set to: {policy}")
+        logger.info(f"Confirmation policy set to: {policy}")
+
+    def set_confirmation_mode(self, enabled: bool) -> None:
+        """Enable or disable confirmation mode.
+
+        If enabled, sets the confirmation policy to AlwaysConfirm.
+        If disabled, sets the confirmation policy to NeverConfirm.
+
+        To set to any other policy, use set_confirmation_policy().
+        """
+        with self.state:
+            if enabled:
+                self.state.confirmation_policy = AlwaysConfirm()
+                logger.info("Confirmation mode enabled")
+            else:
+                self.state.confirmation_policy = NeverConfirm()
+                logger.info("Confirmation mode disabled")
 
     def reject_pending_actions(self, reason: str = "User rejected the action") -> None:
         """Reject all pending actions from the agent.

--- a/openhands/sdk/conversation/state.py
+++ b/openhands/sdk/conversation/state.py
@@ -14,6 +14,7 @@ from openhands.sdk.conversation.types import ConversationID
 from openhands.sdk.event import Event
 from openhands.sdk.io import FileStore, InMemoryFileStore
 from openhands.sdk.logger import get_logger
+from openhands.sdk.security.confirmation_policy import ConfirmationPolicy, NeverConfirm
 from openhands.sdk.utils.protocol import ListLike
 
 
@@ -53,9 +54,7 @@ class ConversationState(BaseModel):
 
     # Enum-based state management
     agent_status: AgentExecutionStatus = Field(default=AgentExecutionStatus.IDLE)
-    confirmation_mode: bool = Field(
-        default=False
-    )  # Keep this as it's a configuration setting
+    confirmation_policy: ConfirmationPolicy = NeverConfirm()
 
     activated_knowledge_microagents: list[str] = Field(
         default_factory=list,

--- a/openhands/sdk/security/confirmation_policy.py
+++ b/openhands/sdk/security/confirmation_policy.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Annotated
 
+from pydantic import field_validator
+
 from openhands.sdk.security.risk import SecurityRisk
 from openhands.sdk.utils.discriminated_union import (
     DiscriminatedUnionMixin,
@@ -11,6 +13,7 @@ from openhands.sdk.utils.discriminated_union import (
 class ConfirmationPolicyBase(DiscriminatedUnionMixin, ABC):
     @abstractmethod
     def should_confirm(self, risk: SecurityRisk = SecurityRisk.UNKNOWN) -> bool:
+        """Determine if an action with the given risk level requires confirmation."""
         pass
 
 
@@ -33,7 +36,18 @@ class ConfirmRisky(ConfirmationPolicyBase):
     threshold: SecurityRisk = SecurityRisk.HIGH
     confirm_unknown: bool = True
 
+    @field_validator("threshold")
+    def validate_threshold(cls, v: SecurityRisk) -> SecurityRisk:
+        if v == SecurityRisk.UNKNOWN:
+            raise ValueError("Threshold cannot be UNKNOWN")
+        return v
+
     def should_confirm(self, risk: SecurityRisk = SecurityRisk.UNKNOWN) -> bool:
         if risk == SecurityRisk.UNKNOWN:
             return self.confirm_unknown
-        return risk >= self.threshold
+
+        # This comparison is reflexive by default, so if the threshold is HIGH we will
+        # still require confirmation for HIGH risk actions. And since the threshold is
+        # guaranteed to never be UNKNOWN (by the validator), we're guaranteed to get a
+        # boolean here.
+        return risk.is_riskier(self.threshold)

--- a/openhands/sdk/security/confirmation_policy.py
+++ b/openhands/sdk/security/confirmation_policy.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+from typing import Annotated
+
+from openhands.sdk.security.risk import SecurityRisk
+from openhands.sdk.utils.discriminated_union import (
+    DiscriminatedUnionMixin,
+    DiscriminatedUnionType,
+)
+
+
+class ConfirmationPolicyBase(DiscriminatedUnionMixin, ABC):
+    @abstractmethod
+    def should_confirm(self, risk: SecurityRisk = SecurityRisk.UNKNOWN) -> bool:
+        pass
+
+
+ConfirmationPolicy = Annotated[
+    ConfirmationPolicyBase, DiscriminatedUnionType[ConfirmationPolicyBase]
+]
+
+
+class AlwaysConfirm(ConfirmationPolicyBase):
+    def should_confirm(self, risk: SecurityRisk = SecurityRisk.UNKNOWN) -> bool:
+        return True
+
+
+class NeverConfirm(ConfirmationPolicyBase):
+    def should_confirm(self, risk: SecurityRisk = SecurityRisk.UNKNOWN) -> bool:
+        return False
+
+
+class ConfirmRisky(ConfirmationPolicyBase):
+    threshold: SecurityRisk = SecurityRisk.HIGH
+    confirm_unknown: bool = True
+
+    def should_confirm(self, risk: SecurityRisk = SecurityRisk.UNKNOWN) -> bool:
+        if risk == SecurityRisk.UNKNOWN:
+            return self.confirm_unknown
+        return risk >= self.threshold

--- a/openhands/sdk/security/risk.py
+++ b/openhands/sdk/security/risk.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 from enum import Enum
-from functools import total_ordering
-from typing import Any
 
 
-@total_ordering
 class SecurityRisk(str, Enum):
     """Security risk levels for actions.
 
@@ -38,13 +35,40 @@ class SecurityRisk(str, Enum):
     def __str__(self) -> str:
         return self.name
 
-    def __lt__(self, other: Any) -> bool:
-        if not isinstance(other, SecurityRisk):
-            return NotImplemented
-        order = {
-            SecurityRisk.UNKNOWN: 0,
+    def is_riskier(self, other: SecurityRisk, reflexive: bool = True) -> bool:
+        """Check if this risk level is riskier than another.
+
+        Risk levels follow the natural ordering: LOW is less risky than MEDIUM, which is
+        less risky than HIGH. UNKNOWN is not comparable to any other level.
+
+        To make this act like a standard well-ordered domain, we reflexively consider
+        risk levels to be riskier than themselves. That is:
+
+            for risk_level in list(SecurityRisk):
+                assert risk_level.is_riskier(risk_level)
+
+            # More concretely:
+            assert SecurityRisk.HIGH.is_riskier(SecurityRisk.HIGH)
+            assert SecurityRisk.MEDIUM.is_riskier(SecurityRisk.MEDIUM)
+            assert SecurityRisk.LOW.is_riskier(SecurityRisk.LOW)
+
+        This can be disabled by setting the `reflexive` parameter to False.
+
+        Args:
+            other (SecurityRisk): The other risk level to compare against.
+            reflexive (bool): Whether the relationship is reflexive.
+
+        Raises:
+            ValueError: If either risk level is UNKNOWN.
+        """
+        if self.value == SecurityRisk.UNKNOWN or other.value == SecurityRisk.UNKNOWN:
+            raise ValueError("Cannot compare unknown risk levels.")
+
+        # Map risk levels to a well-ordered domain for comparison. No need to map
+        # UNKNOWN since we'll already have raised an error by now if either is UNKNOWN.
+        risk_order = {
             SecurityRisk.LOW: 1,
             SecurityRisk.MEDIUM: 2,
             SecurityRisk.HIGH: 3,
         }
-        return order[self] < order[other]
+        return risk_order[self] > risk_order[other] or (reflexive and self == other)

--- a/openhands/sdk/security/risk.py
+++ b/openhands/sdk/security/risk.py
@@ -1,8 +1,11 @@
-"""Security risk levels for action analysis."""
+from __future__ import annotations
 
 from enum import Enum
+from functools import total_ordering
+from typing import Any
 
 
+@total_ordering
 class SecurityRisk(str, Enum):
     """Security risk levels for actions.
 
@@ -34,3 +37,14 @@ class SecurityRisk(str, Enum):
 
     def __str__(self) -> str:
         return self.name
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, SecurityRisk):
+            return NotImplemented
+        order = {
+            SecurityRisk.UNKNOWN: 0,
+            SecurityRisk.LOW: 1,
+            SecurityRisk.MEDIUM: 2,
+            SecurityRisk.HIGH: 3,
+        }
+        return order[self] < order[other]

--- a/tests/sdk/conversation/test_confirmation_mode.py
+++ b/tests/sdk/conversation/test_confirmation_mode.py
@@ -108,7 +108,7 @@ class TestConfirmationMode:
 
     def _make_pending_action(self) -> None:
         """Enable confirmation mode and produce a single pending action."""
-        self.conversation.set_confirmation_mode(AlwaysConfirm())
+        self.conversation.set_confirmation_policy(AlwaysConfirm())
         mock_completion = self._mock_action_once()
         with patch(
             "openhands.sdk.llm.llm.litellm_completion",
@@ -239,11 +239,11 @@ class TestConfirmationMode:
         assert get_unmatched_actions(self.conversation.state.events) == []
 
         # Enable confirmation mode
-        self.conversation.set_confirmation_mode(AlwaysConfirm())
+        self.conversation.set_confirmation_policy(AlwaysConfirm())
         assert self.conversation.state.confirmation_policy == AlwaysConfirm()
 
         # Disable confirmation mode
-        self.conversation.set_confirmation_mode(NeverConfirm())
+        self.conversation.set_confirmation_policy(NeverConfirm())
         assert self.conversation.state.confirmation_policy == NeverConfirm()
 
         # Test rejecting when no actions exist doesn't raise error
@@ -309,7 +309,7 @@ class TestConfirmationMode:
 
     def test_message_only_in_confirmation_mode_does_not_wait(self):
         """Don't confirm agent messages."""
-        self.conversation.set_confirmation_mode(AlwaysConfirm())
+        self.conversation.set_confirmation_policy(AlwaysConfirm())
         mock_completion = self._mock_message_only("Hello, how can I help you?")
         with patch(
             "openhands.sdk.llm.llm.litellm_completion",
@@ -385,7 +385,7 @@ class TestConfirmationMode:
     def test_single_finish_action_skips_confirmation_entirely(self):
         """Test that a single FinishAction skips confirmation entirely."""
         # Enable confirmation mode
-        self.conversation.set_confirmation_mode(AlwaysConfirm())
+        self.conversation.set_confirmation_policy(AlwaysConfirm())
 
         # Mock LLM to return a single FinishAction
         mock_completion = self._mock_finish_action("Task completed successfully!")
@@ -426,7 +426,7 @@ class TestConfirmationMode:
     def test_multiple_actions_with_finish_still_require_confirmation(self):
         """Test that multiple actions (including FinishAction) still require confirmation."""  # noqa: E501
         # Enable confirmation mode
-        self.conversation.set_confirmation_mode(AlwaysConfirm())
+        self.conversation.set_confirmation_policy(AlwaysConfirm())
 
         # Mock LLM to return both a regular action and a FinishAction
         mock_completion = self._mock_multiple_actions_with_finish()

--- a/tests/sdk/conversation/test_conversation_id.py
+++ b/tests/sdk/conversation/test_conversation_id.py
@@ -8,6 +8,7 @@ from openhands.sdk.conversation.state import ConversationState
 from openhands.sdk.conversation.types import ConversationCallbackType
 from openhands.sdk.event.llm_convertible import SystemPromptEvent
 from openhands.sdk.llm import LLM, TextContent
+from openhands.sdk.security.confirmation_policy import AlwaysConfirm, NeverConfirm
 
 
 class DummyAgent(AgentBase):
@@ -63,8 +64,8 @@ def test_conversation_id_persists():
     original_id = conversation.id
 
     # Perform some operations that might affect the conversation
-    conversation.set_confirmation_mode(True)
-    conversation.set_confirmation_mode(False)
+    conversation.set_confirmation_policy(AlwaysConfirm())
+    conversation.set_confirmation_policy(NeverConfirm())
 
     # Check that the ID hasn't changed
     assert conversation.id == original_id

--- a/tests/sdk/conversation/test_pause_functionality.py
+++ b/tests/sdk/conversation/test_pause_functionality.py
@@ -28,6 +28,7 @@ from openhands.sdk.conversation import Conversation
 from openhands.sdk.conversation.state import AgentExecutionStatus
 from openhands.sdk.event import MessageEvent, PauseEvent
 from openhands.sdk.llm import LLM, ImageContent, Message, TextContent
+from openhands.sdk.security.confirmation_policy import AlwaysConfirm
 from openhands.sdk.tool import ActionBase, ObservationBase, Tool, ToolExecutor
 
 
@@ -182,7 +183,7 @@ class TestPauseFunctionality:
     def test_pause_with_confirmation_mode(self, mock_completion):
         """Test that pause before run() with confirmation mode - pause is reset and agent waits for confirmation."""  # noqa: E501
         # Enable confirmation mode
-        self.conversation.set_confirmation_mode(True)
+        self.conversation.set_confirmation_mode(AlwaysConfirm())
         self.conversation.pause()
         assert self.conversation.state.agent_status == AgentExecutionStatus.PAUSED
 

--- a/tests/sdk/conversation/test_pause_functionality.py
+++ b/tests/sdk/conversation/test_pause_functionality.py
@@ -183,7 +183,7 @@ class TestPauseFunctionality:
     def test_pause_with_confirmation_mode(self, mock_completion):
         """Test that pause before run() with confirmation mode - pause is reset and agent waits for confirmation."""  # noqa: E501
         # Enable confirmation mode
-        self.conversation.set_confirmation_mode(AlwaysConfirm())
+        self.conversation.set_confirmation_policy(AlwaysConfirm())
         self.conversation.pause()
         assert self.conversation.state.agent_status == AgentExecutionStatus.PAUSED
 

--- a/tests/sdk/conversation/test_state_serialization.py
+++ b/tests/sdk/conversation/test_state_serialization.py
@@ -14,6 +14,7 @@ from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.conversation.state import AgentExecutionStatus, ConversationState
 from openhands.sdk.event.llm_convertible import MessageEvent, SystemPromptEvent
 from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.security.confirmation_policy import AlwaysConfirm
 from openhands.tools import BashTool, FileEditorTool
 
 
@@ -577,7 +578,7 @@ def test_conversation_state_flags_persistence():
 
         # Set various flags
         state.agent_status = AgentExecutionStatus.FINISHED
-        state.confirmation_mode = True
+        state.confirmation_policy = AlwaysConfirm()
         state.activated_knowledge_microagents = ["agent1", "agent2"]
 
         # State auto-saves, load using Conversation
@@ -590,7 +591,7 @@ def test_conversation_state_flags_persistence():
 
         # Verify flags are preserved
         assert loaded_state.agent_status == AgentExecutionStatus.FINISHED
-        assert loaded_state.confirmation_mode is True
+        assert loaded_state.confirmation_policy == AlwaysConfirm()
         assert loaded_state.activated_knowledge_microagents == ["agent1", "agent2"]
         # Test model_dump equality
         assert loaded_state.model_dump(mode="json") == state.model_dump(mode="json")

--- a/tests/sdk/security/test_confirmation_policy.py
+++ b/tests/sdk/security/test_confirmation_policy.py
@@ -1,0 +1,98 @@
+"""Tests for ConfirmationPolicy classes and serialization."""
+
+import pytest
+from pydantic import BaseModel
+
+from openhands.sdk.security.confirmation_policy import (
+    AlwaysConfirm,
+    ConfirmationPolicy,
+    ConfirmationPolicyBase,
+    NeverConfirm,
+)
+from openhands.sdk.security.risk import SecurityRisk
+
+
+class TestConfirmationPolicyBase:
+    """Tests for the ConfirmationPolicy base class."""
+
+    def test_cannot_instantiate_base_class(self) -> None:
+        """Test that the base class cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            # Of course mypy doesn't want us to do this, so ignore the type check while
+            # we confirm the runtime behavior.
+            ConfirmationPolicyBase()  # type: ignore
+
+    @pytest.mark.parametrize("cls", list(ConfirmationPolicyBase.__subclasses__()))
+    def test_confirmation_policy_container_serialization(
+        self, cls: type[ConfirmationPolicyBase]
+    ) -> None:
+        """Test that a container model with ConfirmationPolicy instances as a field can
+        be serialized.
+        """
+
+        class PolicyContainer(BaseModel):
+            policy: ConfirmationPolicy
+
+        container = PolicyContainer(policy=cls())
+
+        container_dict = container.model_dump_json()
+        restored_container = PolicyContainer.model_validate_json(container_dict)
+
+        assert isinstance(restored_container.policy, cls)
+        assert container.policy == restored_container.policy
+
+
+class TestAlwaysConfirm:
+    """Tests for the AlwaysConfirm policy."""
+
+    @pytest.mark.parametrize("risk", list(SecurityRisk))
+    def test_always_confirm(self, risk: SecurityRisk) -> None:
+        """Test that the policy always confirms, regardless of the inputs."""
+        policy = AlwaysConfirm()
+        assert policy.should_confirm(risk) is True
+
+    def test_roundtrip_serialization(self) -> None:
+        """Test that AlwaysConfirm can be serialized and deserialized correctly."""
+        policy = AlwaysConfirm()
+        policy_dict = policy.model_dump_json()
+        restored_policy = AlwaysConfirm.model_validate_json(policy_dict)
+
+        assert isinstance(restored_policy, AlwaysConfirm)
+
+    def test_polymorphic_serialization(self) -> None:
+        """Test polymorphic serialization and deserialization. This requires we
+        deserialize using the base class.
+        """
+        policy: ConfirmationPolicy = AlwaysConfirm()
+        policy_dict = policy.model_dump_json()
+        restored_policy = ConfirmationPolicyBase.model_validate_json(policy_dict)
+
+        assert isinstance(restored_policy, AlwaysConfirm)
+
+
+class TestNeverConfirm:
+    """Tests for the NeverConfirm policy."""
+
+    @pytest.mark.parametrize("risk", list(SecurityRisk))
+    def test_never_confirm(self, risk: SecurityRisk) -> None:
+        """Test that the policy never confirms, regardless of the inputs."""
+        policy = NeverConfirm()
+        assert policy.should_confirm(risk) is False
+
+    def test_roundtrip_serialization(self) -> None:
+        """Test that NeverConfirm can be serialized and deserialized correctly."""
+        policy = NeverConfirm()
+        policy_dict = policy.model_dump_json()
+        restored_policy = NeverConfirm.model_validate_json(policy_dict)
+
+        assert isinstance(restored_policy, NeverConfirm)
+
+    def test_polymorphic_serialization(self) -> None:
+        """Test polymorphic serialization and deserialization. This requires we
+        deserialize using the base class.
+        """
+        policy: ConfirmationPolicy = NeverConfirm()
+        policy_dict = policy.model_dump_json()
+        restored_policy = ConfirmationPolicyBase.model_validate_json(policy_dict)
+
+        assert isinstance(restored_policy, NeverConfirm)

--- a/tests/sdk/security/test_security_risk.py
+++ b/tests/sdk/security/test_security_risk.py
@@ -1,0 +1,19 @@
+"""Simplified tests for SecurityRisk enum focusing on working functionality."""
+
+from openhands.sdk.security.risk import SecurityRisk
+
+
+def test_security_risk_enum_values():
+    """Test that SecurityRisk enum has expected values."""
+    assert SecurityRisk.UNKNOWN == "UNKNOWN"
+    assert SecurityRisk.LOW == "LOW"
+    assert SecurityRisk.MEDIUM == "MEDIUM"
+    assert SecurityRisk.HIGH == "HIGH"
+
+
+def test_security_risk_string_representation():
+    """Test string representation of SecurityRisk values."""
+    assert str(SecurityRisk.UNKNOWN) == "UNKNOWN"
+    assert str(SecurityRisk.LOW) == "LOW"
+    assert str(SecurityRisk.MEDIUM) == "MEDIUM"
+    assert str(SecurityRisk.HIGH) == "HIGH"

--- a/tests/sdk/security/test_security_risk.py
+++ b/tests/sdk/security/test_security_risk.py
@@ -1,4 +1,8 @@
-"""Simplified tests for SecurityRisk enum focusing on working functionality."""
+"""Comprehensive tests for SecurityRisk enum and is_riskier functionality."""
+
+from itertools import product
+
+import pytest
 
 from openhands.sdk.security.risk import SecurityRisk
 
@@ -17,3 +21,56 @@ def test_security_risk_string_representation():
     assert str(SecurityRisk.LOW) == "LOW"
     assert str(SecurityRisk.MEDIUM) == "MEDIUM"
     assert str(SecurityRisk.HIGH) == "HIGH"
+
+
+def test_riskiness_ordering():
+    """Test basic ordering with is_riskier method."""
+    # Test the natural risk ordering: LOW < MEDIUM < HIGH
+    assert SecurityRisk.MEDIUM.is_riskier(SecurityRisk.LOW)
+    assert SecurityRisk.HIGH.is_riskier(SecurityRisk.MEDIUM)
+    assert SecurityRisk.HIGH.is_riskier(SecurityRisk.LOW)
+
+    # Test the reverse ordering (should be False)
+    assert not SecurityRisk.LOW.is_riskier(SecurityRisk.MEDIUM)
+    assert not SecurityRisk.MEDIUM.is_riskier(SecurityRisk.HIGH)
+    assert not SecurityRisk.LOW.is_riskier(SecurityRisk.HIGH)
+
+
+@pytest.mark.parametrize(
+    "risk_level",
+    [
+        SecurityRisk.LOW,
+        SecurityRisk.MEDIUM,
+        SecurityRisk.HIGH,
+    ],
+)
+def test_riskiness_ordering_is_reflexive(risk_level):
+    """Test that is_riskier is reflexive by default."""
+    assert risk_level.is_riskier(risk_level)
+
+
+@pytest.mark.parametrize(
+    "risk_level",
+    [
+        SecurityRisk.LOW,
+        SecurityRisk.MEDIUM,
+        SecurityRisk.HIGH,
+    ],
+)
+def test_riskiness_ordering_non_reflexive(risk_level):
+    """Test that is_riskier with reflexive=False is non-reflexive."""
+    assert not risk_level.is_riskier(risk_level, reflexive=False)
+
+
+def test_riskiness_ordering_undefined_for_unknown():
+    """Test that comparisons involving UNKNOWN raise ValueError."""
+    for first_risk, second_risk in product(list(SecurityRisk), repeat=2):
+        if SecurityRisk.UNKNOWN in (first_risk, second_risk):
+            with pytest.raises(ValueError):
+                first_risk.is_riskier(second_risk)
+
+        # If there's no UNKNOWN, the comparison should work. To test this we'll call the
+        # function and make sure it returned a boolean.
+        else:
+            comparison = first_risk.is_riskier(second_risk)
+            assert comparison in (True, False)


### PR DESCRIPTION
We were getting some annoying entanglement between confirmation mode and the security analyzer. This PR replaces the confirmation mode flag with `ConfirmationPolicy`, a base class that provides a `should_confirm` method that can be used to characterize precisely when the agent should be asking the user for confirmation.

There are three default policies:
1. `AlwaysConfirm()` is equivalent to `confirmation_mode = True`.
2. `NeverConfirm()` is equivalent to `confirmation_mode = False`.
3. `ConfirmRisky(threshold, confirm_unknown)` only asks for confirmation when a security analyzer places the action risk above `threshold`, unless `confirm_unknown` is set.

The three are models using our normal discriminated union pattern, so they can be easily serialized with the conversation state.