### PR TITLE
Fix CI: Only run build-and-push-image on main or build-docker tag

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -132,11 +132,12 @@ jobs:
                   filters: |
                       docker:
                         - 'openhands/agent_server/docker/**'
+                        - '.github/workflows/server.yml'
 
     build-and-push-image:
         name: Build & Push
         needs: check-docker-changes
-        # Run only on main branch, 'build-docker' tag, or when Docker files are changed
+        # Run only on main branch, 'build-docker' tag, or when Docker files/workflow are changed
         if: >
             github.ref == 'refs/heads/main' ||
             (github.ref_type == 'tag' && github.ref_name == 'build-docker') ||

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -114,12 +114,33 @@ jobs:
                   # Clean up temp schema
                   rm -f "$SCHEMA_PATH"
 
+    check-docker-changes:
+        name: Check Docker Changes
+        runs-on: ubuntu-latest
+        outputs:
+            docker-changed: ${{ steps.changes.outputs.docker }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 0
+
+            - name: Check for Docker changes
+              uses: dorny/paths-filter@v3
+              id: changes
+              with:
+                  filters: |
+                      docker:
+                        - 'openhands/agent_server/docker/**'
+
     build-and-push-image:
         name: Build & Push
-        # Run only on main branch or the 'build-docker' tag
+        needs: check-docker-changes
+        # Run only on main branch, 'build-docker' tag, or when Docker files are changed
         if: >
             github.ref == 'refs/heads/main' ||
-            (github.ref_type == 'tag' && github.ref_name == 'build-docker')
+            (github.ref_type == 'tag' && github.ref_name == 'build-docker') ||
+            needs.check-docker-changes.outputs.docker-changed == 'true'
         outputs:
             image: ${{ steps.build.outputs.image }}
             short_sha: ${{ steps.build.outputs.short_sha }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -4,6 +4,8 @@ name: Agent Server
 on:
     push:
         branches: [main]
+        tags:
+            - build-docker
     pull_request:
         branches: [main]
     workflow_dispatch:
@@ -114,6 +116,10 @@ jobs:
 
     build-and-push-image:
         name: Build & Push
+        # Run only on main branch or the 'build-docker' tag
+        if: >
+            github.ref == 'refs/heads/main' ||
+            (github.ref_type == 'tag' && github.ref_name == 'build-docker')
         outputs:
             image: ${{ steps.build.outputs.image }}
             short_sha: ${{ steps.build.outputs.short_sha }}
@@ -195,7 +201,8 @@ jobs:
     post-image-comment:
         name: Post/Update PR image comment
         needs: build-and-push-image
-        if: github.event_name == 'pull_request'
+        # Only on PRs, and only if the build actually ran and succeeded
+        if: github.event_name == 'pull_request' && needs.build-and-push-image.result == 'success'
         runs-on: ubuntu-latest
         permissions:
             contents: read


### PR DESCRIPTION
## Summary

This PR fixes issue #360 by optimizing the CI workflow to only run the `build-and-push-image` job when necessary, significantly speeding up CI for most PRs.

## Changes Made

1. **Added `build-docker` tag trigger**: Modified the workflow triggers to include the `build-docker` tag alongside the existing `main` branch trigger
2. **Added conditional logic to `build-and-push-image` job**: The job now only runs when:
   - Push is to the `main` branch, OR
   - Push is a tag named `build-docker`
3. **Updated `post-image-comment` job condition**: Now only runs on PRs when the build job actually ran and succeeded

## Impact

- **Faster CI**: Most PRs will no longer trigger Docker builds (3 variants × 2 platforms = 6 builds), significantly reducing CI time
- **Selective builds**: Docker images are still built on main branch pushes and when explicitly requested via the `build-docker` tag
- **Better resource usage**: Reduces unnecessary compute usage on the CI infrastructure

## Testing

The changes are to GitHub Actions workflow configuration only. The logic has been implemented according to the GitHub Actions documentation for conditional job execution.

Fixes #360

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1c508af519804bb9bdced2ac762c48b7)