### PR TITLE
feat: add expose_secrets context parameter for AgentSpec serialization

### DIFF
--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -12,6 +12,7 @@ from pydantic import (
     Field,
     PrivateAttr,
     SecretStr,
+    field_serializer,
     field_validator,
     model_validator,
 )
@@ -293,6 +294,24 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             f"reasoning_effort={self.reasoning_effort}"
         )
         return self
+
+    # =========================================================================
+    # Serializers
+    # =========================================================================
+    @field_serializer(
+        "api_key", "aws_access_key_id", "aws_secret_access_key", when_used="json"
+    )
+    def _serialize_secrets(self, v: SecretStr | None, info):
+        """Serialize secret fields, exposing actual values when expose_secrets context is True."""  # noqa: E501
+        if v is None:
+            return None
+
+        # Check if the 'expose_secrets' flag is in the serialization context
+        if info.context and info.context.get("expose_secrets"):
+            return v.get_secret_value()
+
+        # Let Pydantic handle the default masking
+        return v
 
     # =========================================================================
     # Public API

--- a/tests/sdk/agent/test_agent_spec_secrets.py
+++ b/tests/sdk/agent/test_agent_spec_secrets.py
@@ -1,0 +1,148 @@
+"""Test AgentSpec secret serialization functionality."""
+
+import json
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.sdk.agent.spec import AgentSpec
+from openhands.sdk.llm import LLM
+
+
+@pytest.fixture
+def llm_with_secrets():
+    """Create an LLM with secret fields for testing."""
+    return LLM(
+        model="test-model",
+        api_key=SecretStr("dummy-api-key-123"),
+        aws_access_key_id=SecretStr("dummy-aws-access-key"),
+        aws_secret_access_key=SecretStr("dummy-aws-secret-key"),
+    )
+
+
+def test_agent_spec_default_serialization_masks_secrets(llm_with_secrets):
+    """Test that AgentSpec serialization masks secrets by default."""
+    spec = AgentSpec(llm=llm_with_secrets)
+
+    # Test model_dump_json
+    json_str = spec.model_dump_json()
+    json_data = json.loads(json_str)
+
+    # Verify that secrets are masked in the JSON
+    llm_data = json_data["llm"]
+    assert llm_data["api_key"] == "**********"
+    assert llm_data["aws_access_key_id"] == "**********"
+    assert llm_data["aws_secret_access_key"] == "**********"
+
+    # Verify that actual secret values are not in the JSON string
+    assert "dummy-api-key-123" not in json_str
+    assert "dummy-aws-access-key" not in json_str
+    assert "dummy-aws-secret-key" not in json_str
+
+
+def test_agent_spec_expose_secrets_context_works(llm_with_secrets):
+    """Test that expose_secrets context parameter exposes actual secret values."""
+    spec = AgentSpec(llm=llm_with_secrets)
+
+    # This should expose secrets when context={'expose_secrets': True}
+    json_str = spec.model_dump_json(context={"expose_secrets": True})
+    json_data = json.loads(json_str)
+
+    # Verify that secrets are exposed in the JSON
+    llm_data = json_data["llm"]
+    assert llm_data["api_key"] == "dummy-api-key-123"
+    assert llm_data["aws_access_key_id"] == "dummy-aws-access-key"
+    assert llm_data["aws_secret_access_key"] == "dummy-aws-secret-key"
+
+    # Verify that actual secret values are in the JSON string
+    assert "dummy-api-key-123" in json_str
+    assert "dummy-aws-access-key" in json_str
+    assert "dummy-aws-secret-key" in json_str
+
+
+def test_agent_spec_model_dump_masks_secrets(llm_with_secrets):
+    """Test that AgentSpec model_dump also masks secrets by default."""
+    spec = AgentSpec(llm=llm_with_secrets)
+
+    # Test model_dump
+    data = spec.model_dump()
+
+    # Verify that secrets are masked in the dict
+    llm_data = data["llm"]
+    assert str(llm_data["api_key"]) == "**********"
+    assert str(llm_data["aws_access_key_id"]) == "**********"
+    assert str(llm_data["aws_secret_access_key"]) == "**********"
+
+
+def test_llm_direct_serialization_masks_secrets(llm_with_secrets):
+    """Test that LLM direct serialization masks secrets by default."""
+    # Test model_dump_json
+    json_str = llm_with_secrets.model_dump_json()
+    json_data = json.loads(json_str)
+
+    # Verify that secrets are masked in the JSON
+    assert json_data["api_key"] == "**********"
+    assert json_data["aws_access_key_id"] == "**********"
+    assert json_data["aws_secret_access_key"] == "**********"
+
+    # Verify that actual secret values are not in the JSON string
+    assert "dummy-api-key-123" not in json_str
+    assert "dummy-aws-access-key" not in json_str
+    assert "dummy-aws-secret-key" not in json_str
+
+
+def test_llm_direct_expose_secrets_context_works(llm_with_secrets):
+    """Test that LLM direct expose_secrets context parameter exposes actual secret values."""  # noqa: E501
+    # This should expose secrets when context={'expose_secrets': True}
+    json_str = llm_with_secrets.model_dump_json(context={"expose_secrets": True})
+    json_data = json.loads(json_str)
+
+    # Verify that secrets are exposed in the JSON
+    assert json_data["api_key"] == "dummy-api-key-123"
+    assert json_data["aws_access_key_id"] == "dummy-aws-access-key"
+    assert json_data["aws_secret_access_key"] == "dummy-aws-secret-key"
+
+    # Verify that actual secret values are in the JSON string
+    assert "dummy-api-key-123" in json_str
+    assert "dummy-aws-access-key" in json_str
+    assert "dummy-aws-secret-key" in json_str
+
+
+def test_llm_expose_secrets_context_false_masks_secrets(llm_with_secrets):
+    """Test that LLM with expose_secrets=False still masks secrets."""
+    # This should mask secrets when context={'expose_secrets': False}
+    json_str = llm_with_secrets.model_dump_json(context={"expose_secrets": False})
+    json_data = json.loads(json_str)
+
+    # Verify that secrets are masked in the JSON
+    assert json_data["api_key"] == "**********"
+    assert json_data["aws_access_key_id"] == "**********"
+    assert json_data["aws_secret_access_key"] == "**********"
+
+    # Verify that actual secret values are not in the JSON string
+    assert "dummy-api-key-123" not in json_str
+    assert "dummy-aws-access-key" not in json_str
+    assert "dummy-aws-secret-key" not in json_str
+
+
+def test_llm_with_none_secrets():
+    """Test that LLM with None secret fields works correctly."""
+    llm = LLM(model="test-model")  # No secrets provided
+
+    # Test default serialization
+    json_str = llm.model_dump_json()
+    json_data = json.loads(json_str)
+
+    # Verify that None secrets are serialized as null
+    assert json_data["api_key"] is None
+    assert json_data["aws_access_key_id"] is None
+    assert json_data["aws_secret_access_key"] is None
+
+    # Test with expose_secrets=True
+    json_str = llm.model_dump_json(context={"expose_secrets": True})
+    json_data = json.loads(json_str)
+
+    # Verify that None secrets are still serialized as null
+    assert json_data["api_key"] is None
+    assert json_data["aws_access_key_id"] is None
+    assert json_data["aws_secret_access_key"] is None


### PR DESCRIPTION
## Summary

This PR adds the ability to expose secrets when serializing `AgentSpec` to JSON by adding support for a `context` parameter with an `expose_secrets` flag.

## Changes

### Core Implementation
- **Modified `openhands/sdk/llm/llm.py`**:
  - Added `field_serializer` import from pydantic
  - Implemented `_serialize_secrets()` method that checks for `expose_secrets` context flag
  - Targets `api_key`, `aws_access_key_id`, and `aws_secret_access_key` fields
  - Returns actual secret values when `expose_secrets=True`, otherwise lets Pydantic handle default masking

### Testing
- **Added `tests/sdk/agent/test_agent_spec_secrets.py`**:
  - Comprehensive test suite covering all serialization scenarios
  - Tests for both `AgentSpec` and direct `LLM` serialization
  - Covers default behavior, expose_secrets=True/False, and None values
  - 7 test cases ensuring robust functionality

## Usage

### Default Behavior (unchanged)
```python
spec = AgentSpec(llm=LLM(model="gpt-4", api_key=SecretStr("sk-123")))
json_str = spec.model_dump_json()
# api_key appears as "**********" in JSON
```

### New Feature - Expose Secrets
```python
spec = AgentSpec(llm=LLM(model="gpt-4", api_key=SecretStr("sk-123")))
json_str = spec.model_dump_json(context={"expose_secrets": True})
# api_key appears as "sk-123" in JSON
```

### Direct LLM Serialization
```python
llm = LLM(model="gpt-4", api_key=SecretStr("sk-123"))
json_str = llm.model_dump_json(context={"expose_secrets": True})
# api_key appears as "sk-123" in JSON
```

## Key Features

- ✅ **Backward Compatible**: Default behavior unchanged - secrets remain masked
- ✅ **Flexible**: Works with both `AgentSpec` and direct `LLM` serialization
- ✅ **Secure by Default**: Secrets only exposed when explicitly requested
- ✅ **Robust**: Handles `None` values and edge cases properly
- ✅ **Well Tested**: Comprehensive test coverage for all scenarios

## Testing

All tests pass:
```bash
uv run pytest tests/sdk/agent/test_agent_spec_secrets.py -v
# 7 passed in 0.06s
```

The implementation follows the project's coding standards and passes all pre-commit hooks including type checking, linting, and formatting.

## Related

This addresses the need to serialize `AgentSpec` configurations with actual secret values for specific use cases while maintaining security by default.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ea848a8b67e942b0baeb10d3706cdc90)