### PR TITLE
Use Blacksmith runners for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     dispatch:
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         strategy:
             matrix:
                 repo: [All-Hands-AI/docs]

--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -136,7 +136,7 @@ jobs:
     consolidate-results:
         needs: run-integration-tests
         if: always() && (github.event.label.name == 'integration-test' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         permissions:
             contents: read
             pull-requests: write

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     pre-commit:
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
 
         steps:
             - name: Checkout code

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -74,7 +74,7 @@ jobs:
 
     check-openapi-schema:
         name: Check OpenAPI Schema
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
 
         steps:
             - name: Checkout PR branch
@@ -116,7 +116,7 @@ jobs:
 
     check-docker-changes:
         name: Check Docker Changes
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         outputs:
             docker-changed: ${{ steps.changes.outputs.docker }}
         steps:
@@ -225,7 +225,7 @@ jobs:
         needs: build-and-push-image
         # Only on PRs, and only if the build actually ran and succeeded
         if: github.event_name == 'pull_request' && needs.build-and-push-image.result == 'success'
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         permissions:
             contents: read
             pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
     sdk-tests:
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -67,7 +67,7 @@ jobs:
                   if-no-files-found: warn
 
     tools-tests:
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -121,7 +121,7 @@ jobs:
                   if-no-files-found: warn
 
     agent-server-tests:
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -175,7 +175,7 @@ jobs:
                   if-no-files-found: warn
 
     cross-tests:
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -231,7 +231,7 @@ jobs:
                   if-no-files-found: warn
 
     coverage-report:
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         needs: [sdk-tests, tools-tests, agent-server-tests, cross-tests]
         if: always() && github.event_name == 'pull_request'
         steps:


### PR DESCRIPTION
## Summary

This PR updates all GitHub Actions workflows to use Blacksmith runners instead of GitHub's standard `ubuntu-latest` runners to improve CI performance and speed up test execution.

## Changes Made

- **tests.yml**: Updated all test jobs (`sdk-tests`, `tools-tests`, `agent-server-tests`, `cross-tests`, `coverage-report`) to use `blacksmith-2vcpu-ubuntu-2404`
- **precommit.yml**: Updated pre-commit job to use `blacksmith-2vcpu-ubuntu-2404`
- **server.yml**: Updated remaining jobs (`check-openapi-schema`, `check-docker-changes`, `post-image-comment`) to use `blacksmith-2vcpu-ubuntu-2404`
- **integration-runner.yml**: Updated `consolidate-results` job to use `blacksmith-2vcpu-ubuntu-2404`
- **deploy-docs.yml**: Updated dispatch job to use `blacksmith-2vcpu-ubuntu-2404`

## Benefits

- **Faster CI execution**: Blacksmith runners provide better performance than standard GitHub runners
- **Consistent runner environment**: All workflows now use the same Blacksmith runner type for consistency
- **Cost efficiency**: Blacksmith runners are optimized for performance

## Testing

- All workflow files pass YAML formatting checks
- Pre-commit hooks run successfully on all modified files
- No functional changes to workflow logic, only runner specifications

Fixes #369

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/71db06b1c80a43d1b76941802369fa4c)