### PR TITLE
Expand webhook protocol to support conversation lifecycle events

### DIFF
--- a/openhands/agent_server/config.py
+++ b/openhands/agent_server/config.py
@@ -26,8 +26,9 @@ class WebhookSpec(BaseModel):
         ),
     )
     method: Literal["POST", "PUT", "PATCH"] = "POST"
-    webhook_url: str = Field(
-        description="The URL of the webhook to which to post lists of events"
+    base_url: str = Field(
+        description="The base URL of the webhook service. Events will be sent to "
+        "{base_url}/events and conversation info to {base_url}/conversations"
     )
     headers: dict[str, str] = Field(default_factory=dict)
 


### PR DESCRIPTION
## Summary

This PR expands the webhook protocol to support conversation lifecycle events with improved URL structure and endpoint separation.

## Changes Made

### 🔄 **Breaking Changes**
- **WebhookSpec**: Changed `webhook_url` field to `base_url` for cleaner URL construction
- Users will need to update their webhook configuration to use `base_url` instead of `webhook_url`

### ✨ **New Features**
- **Event Endpoint**: Events are now sent to `{base_url}/events` (batched as before)
- **Conversation Endpoint**: New conversation lifecycle events sent to `{base_url}/conversations` (unbatched)
- **ConversationWebhookSubscriber**: New class specifically for conversation lifecycle notifications
- **Lifecycle Integration**: Webhooks now notify on conversation start, pause, and delete events

### 🏗️ **Implementation Details**
- Modified `WebhookSubscriber._post_events()` to append "/events" to base_url
- Created `ConversationWebhookSubscriber` class with immediate posting (no batching)
- Integrated conversation webhooks into `ConversationService` lifecycle methods
- Added `_notify_conversation_webhooks()` helper method for consistent notification handling
- Both webhook types support same authentication and retry logic

### 🧪 **Testing**
- Updated all existing tests to use `base_url` parameter
- Added comprehensive tests for `ConversationWebhookSubscriber`
- All 100 tests passing
- Integration tested with mock HTTP requests

## Protocol Changes

**Before:**
```
webhook_url: "https://example.com/webhook"
→ Events sent directly to webhook URL
→ No conversation lifecycle webhooks
```

**After:**
```
base_url: "https://example.com"
→ Events sent to https://example.com/events (batched)
→ Conversations sent to https://example.com/conversations (unbatched)
→ Conversation lifecycle: start, pause, stop/delete
```

## Files Changed
- `openhands/agent_server/config.py` - Updated WebhookSpec field
- `openhands/agent_server/conversation_service.py` - Added ConversationWebhookSubscriber and lifecycle integration
- `tests/agent_server/test_webhook_subscriber.py` - Updated tests and added new test cases

## Backward Compatibility
⚠️ **Breaking Change**: The field name change from `webhook_url` to `base_url` requires configuration updates, but provides a more structured and extensible webhook protocol.

## Testing Instructions
1. Configure webhook with `base_url` instead of `webhook_url`
2. Set up endpoints at `{base_url}/events` and `{base_url}/conversations`
3. Start/pause/delete conversations to see lifecycle webhooks
4. Regular events will continue to be batched and sent to `/events`

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b2fc99dc2dcb4a0885b8f070af1a8697)