### PR TITLE
docs(spec): fix AgentSpec examples in comments and align README with examples

### DIFF
--- a/openhands/sdk/agent/spec.py
+++ b/openhands/sdk/agent/spec.py
@@ -78,8 +78,9 @@ class AgentSpec(OpenHandsModel):
                 ],
                 "system_message_suffix": "Always finish your response "
                 "with the word 'yay!'",
-                "user_message_prefix": "The first character of your "
-                "response should be 'I'",
+                "user_message_suffix": (
+                    "The first character of your response should be 'I'"
+                ),
             }
         ],
     )


### PR DESCRIPTION
Summary
- Update AgentSpec examples in code comments to use user_message_suffix instead of user_message_prefix
- Wrap long example string to satisfy E501
- README already aligned previously to match examples and presets

Details
- openhands/sdk/agent/spec.py: Replace user_message_prefix with user_message_suffix in the examples dict; break line to comply with ruff E501.
- README.md previously updated to reflect get_default_tools, Agent.from_spec, LLMRegistry usage, and example list including 15–17.

Testing
- Ran pre-commit on changed files (ruff, pycodestyle, pyright) — all passed.

Notes
- No functional code logic changed; comments/docs only.
- Branch includes just the targeted edits.

Co-authored-by: openhands <openhands@all-hands.dev>