### PR TITLE
chore(visualization): remove dim everywhere, fix diff newline

### DIFF
--- a/openhands/sdk/event/condenser.py
+++ b/openhands/sdk/event/condenser.py
@@ -39,7 +39,7 @@ class Condensation(EventBase):
 
         text.append("Auto Conversation Condensation Triggered.\n", style="bold")
 
-        text.append(f"Forgetting {len(self.forgotten_event_ids)} events\n", style="dim")
+        text.append(f"Forgetting {len(self.forgotten_event_ids)} events\n")
         if self.summary:
             text.append("\n[Summary of Events Being Forgotten]\n", style="bold")
             text.append(f"{self.summary}\n")

--- a/openhands/sdk/event/llm_convertible.py
+++ b/openhands/sdk/event/llm_convertible.py
@@ -47,13 +47,10 @@ class SystemPromptEvent(LLMConvertibleEvent):
                 content.append(
                     f"\n  - {tool_fn['name']}: "
                     f"{tool_fn['description'].split('\n')[0][:100]}...\n",
-                    style="dim",
                 )
-                content.append(f"  Parameters: {params_str}", style="dim")
+                content.append(f"  Parameters: {params_str}")
             else:
-                content.append(
-                    f"\n  - Cannot access .function for {tool_display}", style="dim"
-                )
+                content.append(f"\n  - Cannot access .function for {tool_display}")
         return content
 
     def to_llm_message(self) -> Message:
@@ -253,13 +250,12 @@ class MessageEvent(LLMConvertibleEvent):
             full_content = "".join(text_parts)
             content.append(full_content)
         else:
-            content.append("[no text content]", style="dim")
+            content.append("[no text content]")
 
         # Add microagent information if present
         if self.activated_microagents:
             content.append(
                 f"\nActivated Microagents: {', '.join(self.activated_microagents)}",
-                style="dim",
             )
 
         # Add extended content if available
@@ -268,7 +264,7 @@ class MessageEvent(LLMConvertibleEvent):
                 isinstance(c, ImageContent) for c in self.extended_content
             ), "Extended content should not contain images"
             text_parts = content_to_str(self.extended_content)
-            content.append("\nPrompt Extension based on Agent Context:\n", style="dim")
+            content.append("\nPrompt Extension based on Agent Context:\n")
             content.append(" ".join(text_parts))
 
         return content

--- a/openhands/sdk/tool/schema.py
+++ b/openhands/sdk/tool/schema.py
@@ -197,5 +197,5 @@ class ObservationBase(Schema, DiscriminatedUnionMixin, ABC):
             full_content = "".join(text_parts)
             content.append(full_content)
         else:
-            content.append("[no text content]", style="dim")
+            content.append("[no text content]")
         return content

--- a/openhands/tools/execute_bash/definition.py
+++ b/openhands/tools/execute_bash/definition.py
@@ -45,16 +45,16 @@ class ExecuteBashAction(ActionBase):
         if self.command:
             content.append(self.command, style="white")
         else:
-            content.append("[empty command]", style="dim italic")
+            content.append("[empty command]", style="italic")
 
         # Add metadata if present
         if self.is_input:
             content.append(" ", style="white")
-            content.append("(input to running process)", style="dim yellow")
+            content.append("(input to running process)", style="yellow")
 
         if self.timeout is not None:
             content.append(" ", style="white")
-            content.append(f"[timeout: {self.timeout}s]", style="dim cyan")
+            content.append(f"[timeout: {self.timeout}s]", style="cyan")
 
         return content
 
@@ -128,7 +128,7 @@ class ExecuteBashObservation(ObservationBase):
                     ):
                         content.append(line, style="yellow")
                     elif line.startswith("+ "):  # bash -x output
-                        content.append(line, style="dim cyan")
+                        content.append(line, style="cyan")
                     else:
                         content.append(line, style="white")
                 content.append("\n")
@@ -138,14 +138,14 @@ class ExecuteBashObservation(ObservationBase):
             if self.metadata.working_dir:
                 content.append("\n📁 ", style="blue")
                 content.append(
-                    f"Working directory: {self.metadata.working_dir}", style="dim blue"
+                    f"Working directory: {self.metadata.working_dir}", style="blue"
                 )
 
             if self.metadata.py_interpreter_path:
                 content.append("\n🐍 ", style="green")
                 content.append(
                     f"Python interpreter: {self.metadata.py_interpreter_path}",
-                    style="dim green",
+                    style="green",
                 )
 
             if (

--- a/openhands/tools/str_replace_editor/utils/diff.py
+++ b/openhands/tools/str_replace_editor/utils/diff.py
@@ -112,7 +112,7 @@ def visualize_diff(
     op_type = "edit" if change_applied else "ATTEMPTED edit"
     for i, cur_edit_group in enumerate(edit_groups):
         if i != 0:
-            content.append("-------------------------", style="dim")
+            content.append("\n-------------------------\n")
         content.append(f"[begin of {op_type} {i + 1} / {len(edit_groups)}]\n")
         content.append(f"(content before {op_type})\n")
         for line in cur_edit_group.before_edits:

--- a/openhands/tools/task_tracker/definition.py
+++ b/openhands/tools/task_tracker/definition.py
@@ -57,7 +57,7 @@ class TaskTrackerAction(ActionBase):
 
         # Show task count if planning
         if self.command == "plan" and self.task_list:
-            content.append(f" ({len(self.task_list)} tasks)", style="dim")
+            content.append(f" ({len(self.task_list)} tasks)")
 
         return content
 
@@ -126,13 +126,13 @@ class TaskTrackerObservation(ObservationBase):
 
                 # NEW: show notes under the title if present
                 if task.notes:
-                    content.append("\n   Notes: " + task.notes, style="italic dim")
+                    content.append("\n   Notes: " + task.notes, style="italic")
 
                 if i < len(self.task_list):
                     content.append("\n")
         else:
             content.append("📝 ", style="blue")
-            content.append("Task list is empty", style="dim")
+            content.append("Task list is empty")
 
         return content
 


### PR DESCRIPTION
Newline isn't add properly for str replace editor diff visualization

<img width="1574" height="1174" alt="image" src="https://github.com/user-attachments/assets/b0442353-bdba-4b9c-9e18-090ef99ed92c" />


It also removes all "dim" element because they looks terrible on a full black terminal background:
<img width="2462" height="788" alt="image" src="https://github.com/user-attachments/assets/167f2ad8-73de-43a2-bccc-8b2561b6821c" />
