### PR TITLE
Fix: Reverse --reload flag logic to default to False

### DIFF
--- a/openhands/agent_server/__main__.py
+++ b/openhands/agent_server/__main__.py
@@ -12,11 +12,11 @@ def main():
         "--port", type=int, default=8000, help="Port to bind to (default: 8000)"
     )
     parser.add_argument(
-        "--no-reload",
+        "--reload",
         dest="reload",
-        default=True,
-        action="store_false",
-        help="Disable auto-reload (enabled by default for development)",
+        default=False,
+        action="store_true",
+        help="Enable auto-reload (disabled by default)",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Problem
The agent server was defaulting to auto-reload enabled, causing multiprocessing compatibility issues in production environments. Users were getting errors like:
```
openhands-agent-server: error: unrecognized arguments: -B -S -I -c from multiprocessing.resource_tracker import main;main(5)
```

## Solution
Reversed the reload flag logic:
- **Before**: `--no-reload` flag (default: `reload=True`)
- **After**: `--reload` flag (default: `reload=False`)

## Changes
- Changed flag from `--no-reload` to `--reload`
- Changed default from `True` to `False` 
- Changed action from `store_false` to `store_true`
- Updated help text to reflect new behavior

## Benefits
- ✅ Auto-reload disabled by default for better production behavior
- ✅ Fixes multiprocessing compatibility issues
- ✅ Users can still enable auto-reload with `--reload` for development
- ✅ More intuitive flag naming (positive action vs negative)

## Testing
- Verified default behavior: `reload=False`
- Verified `--reload` flag: `reload=True`
- Verified old `--no-reload` flag is rejected
- All pre-commit checks passed

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c90cf19737404085b673a94d9a8e892d)