### PR TITLE
Default Docker user and group IDs to 1000 in agent_server

### DIFF
--- a/openhands/agent_server/docker/Dockerfile
+++ b/openhands/agent_server/docker/Dockerfile
@@ -2,8 +2,8 @@
 
 ARG BASE_IMAGE=nikolaik/python-nodejs:python3.12-nodejs22
 ARG USERNAME=openhands
-ARG UID=10001
-ARG GID=10001
+ARG UID=1000
+ARG GID=1000
 ARG PORT=8000
 
 ############################


### PR DESCRIPTION
## Summary

This PR changes the default user ID (UID) and group ID (GID) in the agent_server Dockerfile from 10001 to 1000.

## Changes

- Updated `ARG UID=10001` to `ARG UID=1000`
- Updated `ARG GID=10001` to `ARG GID=1000`

## Rationale

Using UID/GID 1000 is more conventional and commonly used in Docker containers, as it's typically the first non-system user ID on most Linux systems. This change makes the container more compatible with standard development environments and reduces potential permission issues when mounting volumes.

## Impact

- The default user and group IDs are now 1000 instead of 10001
- Build arguments can still be used to override these values if needed
- No breaking changes - existing builds that explicitly set UID/GID will continue to work

## Testing

- [x] Dockerfile syntax is valid
- [x] Pre-commit hooks pass
- [x] No functional changes to the application logic

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8c1416d058604bc6a6d5c8bfe0922d08)