### PR TITLE
Fix persistence path in default agent

### DIFF
--- a/openhands/sdk/preset/default.py
+++ b/openhands/sdk/preset/default.py
@@ -46,7 +46,7 @@ def get_default_tools(
     persistence_path = persistence_dir or os.path.join(working_dir, ".openhands")
     tool_specs = [
         ToolSpec(name="BashTool", params={"working_dir": working_dir}),
-        ToolSpec(name="FileEditorTool"),
+        ToolSpec(name="FileEditorTool", params={"workspace_root": working_dir}),
         ToolSpec(name="TaskTrackerTool", params={"save_dir": persistence_path}),
     ]
     if enable_browser:

--- a/openhands/sdk/preset/default.py
+++ b/openhands/sdk/preset/default.py
@@ -1,5 +1,7 @@
 """Default preset configuration for OpenHands agents."""
 
+import os
+
 from openhands.sdk import Agent
 from openhands.sdk.context.condenser import (
     LLMSummarizingCondenser,
@@ -35,17 +37,17 @@ def register_default_tools(enable_browser: bool = True) -> None:
 
 def get_default_tools(
     working_dir: str,
+    persistence_dir: str | None = None,
     enable_browser: bool = True,
 ) -> list[ToolSpec]:
     """Get the default set of tool specifications for the standard experience."""
     register_default_tools(enable_browser=enable_browser)
 
+    persistence_path = persistence_dir or os.path.join(working_dir, ".openhands")
     tool_specs = [
         ToolSpec(name="BashTool", params={"working_dir": working_dir}),
         ToolSpec(name="FileEditorTool"),
-        ToolSpec(
-            name="TaskTrackerTool", params={"save_dir": f"{working_dir}/.openhands"}
-        ),
+        ToolSpec(name="TaskTrackerTool", params={"save_dir": persistence_path}),
     ]
     if enable_browser:
         tool_specs.append(ToolSpec(name="BrowserToolSet"))
@@ -64,10 +66,12 @@ def get_default_condenser(llm: LLM) -> CondenserBase:
 def get_default_agent(
     llm: LLM,
     working_dir: str,
+    persistence_dir: str | None = None,
     cli_mode: bool = False,
 ) -> Agent:
     tool_specs = get_default_tools(
         working_dir=working_dir,
+        persistence_dir=persistence_dir,
         # Disable browser tools in CLI mode
         enable_browser=not cli_mode,
     )

--- a/tests/sdk/preset/test_default_preset.py
+++ b/tests/sdk/preset/test_default_preset.py
@@ -157,3 +157,36 @@ def test_get_default_agent_tool_order(basic_llm):
     # Other tools should come before BrowserToolSet
     expected_order = ["BashTool", "FileEditorTool", "TaskTrackerTool", "BrowserToolSet"]
     assert tool_names == expected_order
+
+
+def test_get_default_agent_with_custom_persistence_dir(basic_llm):
+    """Test that custom persistence directory is used for TaskTrackerTool save_dir."""
+    working_dir = "/test/workspace"
+    custom_persistence_dir = "/custom/persistence"
+
+    # Test with custom persistence_dir
+    agent = get_default_agent(
+        llm=basic_llm, working_dir=working_dir, persistence_dir=custom_persistence_dir
+    )
+
+    # Find TaskTrackerTool to verify it uses the custom persistence_dir
+    task_tracker_spec = None
+    for tool in agent.tools:
+        if tool.name == "TaskTrackerTool":
+            task_tracker_spec = tool
+            break
+
+    assert task_tracker_spec is not None
+    assert task_tracker_spec.params["save_dir"] == custom_persistence_dir
+
+    # Test without persistence_dir (should default to working_dir/.openhands)
+    agent_default = get_default_agent(llm=basic_llm, working_dir=working_dir)
+
+    task_tracker_spec_default = None
+    for tool in agent_default.tools:
+        if tool.name == "TaskTrackerTool":
+            task_tracker_spec_default = tool
+            break
+
+    assert task_tracker_spec_default is not None
+    assert task_tracker_spec_default.params["save_dir"] == f"{working_dir}/.openhands"


### PR DESCRIPTION
### Problem

Currently, the BashTool and the agent’s persistence data share the same directory (working_dir). This means either the agent works within the persistence related directory (unideal) or the persistence related data ends up in the agent's workspace (ok if explicitly desired)

### Solution

Maintain a clean boundary between the working directory and persistence related paths. If not provided, the working dir + `.openhands` is the fallback default. 