### PR TITLE
Fix security analyzer

### DIFF
--- a/examples/04_confirmation_mode_example.py
+++ b/examples/04_confirmation_mode_example.py
@@ -2,6 +2,7 @@
 
 import os
 import signal
+from typing import Callable
 
 from pydantic import SecretStr
 
@@ -11,6 +12,70 @@ from openhands.sdk.event.utils import get_unmatched_actions
 from openhands.sdk.security.confirmation_policy import AlwaysConfirm, NeverConfirm
 from openhands.sdk.tool import ToolSpec, register_tool
 from openhands.tools.execute_bash import BashTool
+
+
+# Make ^C a clean exit instead of a stack trace
+signal.signal(signal.SIGINT, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+
+def _print_action_preview(pending_actions) -> None:
+    print(f"\n🔍 Agent created {len(pending_actions)} action(s) awaiting confirmation:")
+    for i, action in enumerate(pending_actions, start=1):
+        snippet = str(action.action)[:100].replace("\n", " ")
+        print(f"  {i}. {action.tool_name}: {snippet}...")
+
+
+def confirm_in_console(pending_actions) -> bool:
+    """
+    Return True to approve, False to reject.
+    Default to 'no' on EOF/KeyboardInterrupt (matches original behavior).
+    """
+    _print_action_preview(pending_actions)
+    while True:
+        try:
+            ans = (
+                input("\nDo you want to execute these actions? (yes/no): ")
+                .strip()
+                .lower()
+            )
+        except (EOFError, KeyboardInterrupt):
+            print("\n❌ No input received; rejecting by default.")
+            return False
+
+        if ans in ("yes", "y"):
+            print("✅ Approved — executing actions…")
+            return True
+        if ans in ("no", "n"):
+            print("❌ Rejected — skipping actions…")
+            return False
+        print("Please enter 'yes' or 'no'.")
+
+
+def run_until_finished(conversation: Conversation, confirmer: Callable) -> None:
+    """
+    Drive the conversation until FINISHED.
+    If WAITING_FOR_CONFIRMATION, ask the confirmer;
+    on reject, call reject_pending_actions().
+    Preserves original error if agent waits but no actions exist.
+    """
+    while conversation.state.agent_status != AgentExecutionStatus.FINISHED:
+        if (
+            conversation.state.agent_status
+            == AgentExecutionStatus.WAITING_FOR_CONFIRMATION
+        ):
+            pending = get_unmatched_actions(conversation.state.events)
+            if not pending:
+                raise RuntimeError(
+                    "⚠️ Agent is waiting for confirmation but no pending actions "
+                    "were found. This should not happen."
+                )
+            if not confirmer(pending):
+                conversation.reject_pending_actions("User rejected the actions")
+                # Let the agent produce a new step or finish
+                continue
+
+        print("▶️  Running conversation.run()…")
+        conversation.run()
 
 
 print("=== OpenHands Agent SDK — Confirmation Mode Example ===")
@@ -32,165 +97,24 @@ tools = [ToolSpec(name="BashTool", params={"working_dir": cwd})]
 # Agent and Conversation with confirmation mode enabled
 agent = Agent(llm=llm, tools=tools)
 conversation = Conversation(agent=agent)
+
+# 1) Confirmation mode ON
 conversation.set_confirmation_policy(AlwaysConfirm())
-
-# Make ^C a clean exit instead of a stack trace
-signal.signal(signal.SIGINT, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
-
 print("\n1) Command that will likely create actions…")
 conversation.send_message("Please list the files in the current directory using ls -la")
+run_until_finished(conversation, confirm_in_console)
 
-# Run conversation with confirmation handling
-while conversation.state.agent_status != AgentExecutionStatus.FINISHED:
-    # If agent is waiting for confirmation, preview actions and ask user
-    if conversation.state.agent_status == AgentExecutionStatus.WAITING_FOR_CONFIRMATION:
-        pending_actions = get_unmatched_actions(conversation.state.events)
-
-        if pending_actions:
-            # Build short previews for display
-            print(
-                f"\n🔍 Agent created {len(pending_actions)} action(s) awaiting "
-                "confirmation:"
-            )
-            for i, action in enumerate(pending_actions):
-                snippet = str(action.action)[:100].replace("\n", " ")
-                print(f"  {i + 1}. {action.tool_name}: {snippet}...")
-
-            # Ask for user confirmation
-            while True:
-                try:
-                    user_input = (
-                        input("\nDo you want to execute these actions? (yes/no): ")
-                        .strip()
-                        .lower()
-                    )
-                except (EOFError, KeyboardInterrupt):
-                    print("\n❌ No input received; rejecting by default.")
-                    user_input = "no"
-                    break
-
-                if user_input in ("yes", "y"):
-                    print("✅ Approved — executing actions…")
-                    break
-                elif user_input in ("no", "n"):
-                    print("❌ Rejected — skipping actions…")
-                    conversation.reject_pending_actions("User rejected the actions")
-                    break
-                else:
-                    print("Please enter 'yes' or 'no'.")
-
-            if user_input in ("no", "n"):
-                continue  # Loop continues — the agent may produce a new step or finish
-        else:
-            # Defensive: clear the flag if somehow set without actions
-            print(
-                "⚠️ Agent is waiting for confirmation but no pending actions were found."
-            )
-            conversation.state.agent_status = AgentExecutionStatus.IDLE
-
-    print("▶️  Running conversation.run()…")
-    conversation.run()
-
+# 2) A command the user may choose to reject
 print("\n2) Command the user may choose to reject…")
 conversation.send_message("Please create a file called 'dangerous_file.txt'")
+run_until_finished(conversation, confirm_in_console)
 
-# Run conversation with confirmation handling
-while conversation.state.agent_status != AgentExecutionStatus.FINISHED:
-    if conversation.state.agent_status == AgentExecutionStatus.WAITING_FOR_CONFIRMATION:
-        pending_actions = get_unmatched_actions(conversation.state.events)
-
-        if pending_actions:
-            print(
-                f"\n🔍 Agent created {len(pending_actions)} action(s) awaiting "
-                "confirmation:"
-            )
-            for i, action in enumerate(pending_actions):
-                snippet = str(action.action)[:100].replace("\n", " ")
-                print(f"  {i + 1}. {action.tool_name}: {snippet}...")
-
-            while True:
-                try:
-                    user_input = (
-                        input("\nDo you want to execute these actions? (yes/no): ")
-                        .strip()
-                        .lower()
-                    )
-                except (EOFError, KeyboardInterrupt):
-                    print("\n❌ No input received; rejecting by default.")
-                    user_input = "no"
-                    break
-
-                if user_input in ("yes", "y"):
-                    print("✅ Approved — executing actions…")
-                    break
-                elif user_input in ("no", "n"):
-                    print("❌ Rejected — skipping actions…")
-                    conversation.reject_pending_actions("User rejected the actions")
-                    break
-                else:
-                    print("Please enter 'yes' or 'no'.")
-
-            if user_input in ("no", "n"):
-                continue
-        else:
-            print(
-                "⚠️ Agent is waiting for confirmation but no pending actions were found."
-            )
-            conversation.state.agent_status = AgentExecutionStatus.IDLE
-
-    print("▶️  Running conversation.run()…")
-    conversation.run()
-
+# 3) Simple greeting (no actions expected)
 print("\n3) Simple greeting (no actions expected)…")
 conversation.send_message("Just say hello to me")
+run_until_finished(conversation, confirm_in_console)
 
-# Run conversation with confirmation handling
-while conversation.state.agent_status != AgentExecutionStatus.FINISHED:
-    if conversation.state.agent_status == AgentExecutionStatus.WAITING_FOR_CONFIRMATION:
-        pending_actions = get_unmatched_actions(conversation.state.events)
-
-        if pending_actions:
-            print(
-                f"\n🔍 Agent created {len(pending_actions)} action(s) awaiting "
-                "confirmation:"
-            )
-            for i, action in enumerate(pending_actions):
-                snippet = str(action.action)[:100].replace("\n", " ")
-                print(f"  {i + 1}. {action.tool_name}: {snippet}...")
-
-            while True:
-                try:
-                    user_input = (
-                        input("\nDo you want to execute these actions? (yes/no): ")
-                        .strip()
-                        .lower()
-                    )
-                except (EOFError, KeyboardInterrupt):
-                    print("\n❌ No input received; rejecting by default.")
-                    user_input = "no"
-                    break
-
-                if user_input in ("yes", "y"):
-                    print("✅ Approved — executing actions…")
-                    break
-                elif user_input in ("no", "n"):
-                    print("❌ Rejected — skipping actions…")
-                    conversation.reject_pending_actions("User rejected the actions")
-                    break
-                else:
-                    print("Please enter 'yes' or 'no'.")
-
-            if user_input in ("no", "n"):
-                continue
-        else:
-            print(
-                "⚠️ Agent is waiting for confirmation but no pending actions were found."
-            )
-            conversation.state.agent_status = AgentExecutionStatus.IDLE
-
-    print("▶️  Running conversation.run()…")
-    conversation.run()
-
+# 4) Disable confirmation mode and run commands directly
 print("\n4) Disable confirmation mode and run a command…")
 conversation.set_confirmation_policy(NeverConfirm())
 conversation.send_message("Please echo 'Hello from confirmation mode example!'")
@@ -204,10 +128,10 @@ conversation.run()
 print("\n=== Example Complete ===")
 print("Key points:")
 print(
-    "- conversation.run() creates actions; confirmation mode sets "
-    "agent_status=WAITING_FOR_CONFIRMATION"
+    "- conversation.run() creates actions; confirmation mode "
+    "sets agent_status=WAITING_FOR_CONFIRMATION"
 )
-print("- User confirmation is handled inline with input() prompts")
-print("- Rejection uses conversation.reject_pending_actions() and continues the loop")
+print("- User confirmation is handled via a single reusable function")
+print("- Rejection uses conversation.reject_pending_actions() and the loop continues")
 print("- Simple responses work normally without actions")
-print("- Confirmation mode can be toggled with conversation.set_confirmation_mode()")
+print("- Confirmation policy is toggled with conversation.set_confirmation_policy()")

--- a/examples/16_llm_security_analyzer.py
+++ b/examples/16_llm_security_analyzer.py
@@ -14,6 +14,7 @@ from pydantic import SecretStr
 from openhands.sdk import LLM, Agent, Conversation, LocalFileStore
 from openhands.sdk.conversation.state import AgentExecutionStatus
 from openhands.sdk.event.utils import get_unmatched_actions
+from openhands.sdk.security.confirmation_policy import ConfirmRisky
 from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.tool import ToolSpec, register_tool
 from openhands.tools.execute_bash import BashTool
@@ -116,6 +117,7 @@ file_store = LocalFileStore(f"./.conversations/{conversation_id}")
 conversation = Conversation(
     agent=agent, conversation_id=conversation_id, persist_filestore=file_store
 )
+conversation.set_confirmation_policy(ConfirmRisky())
 
 print("\n1) Safe command (LOW risk - should execute automatically)...")
 conversation.send_message("List files in the current directory")

--- a/examples/16_llm_security_analyzer.py
+++ b/examples/16_llm_security_analyzer.py
@@ -1,4 +1,4 @@
-"""OpenHands Agent SDK — LLM Security Analyzer Example (Simplified)
+"""OpenHands Agent SDK — LLM Security Analyzer Example
 
 This example shows how to use the LLMSecurityAnalyzer to automatically
 evaluate security risks of actions before execution.

--- a/examples/16_llm_security_analyzer.py
+++ b/examples/16_llm_security_analyzer.py
@@ -1,11 +1,13 @@
-"""OpenHands Agent SDK — LLM Security Analyzer Example
+"""OpenHands Agent SDK — LLM Security Analyzer Example (Simplified)
 
 This example shows how to use the LLMSecurityAnalyzer to automatically
 evaluate security risks of actions before execution.
 """
 
 import os
+import signal
 import uuid
+from typing import Callable
 
 from pydantic import SecretStr
 
@@ -18,7 +20,74 @@ from openhands.tools.execute_bash import BashTool
 from openhands.tools.str_replace_editor import FileEditorTool
 
 
-print("=== LLM Security Analyzer Example ===")
+# Clean ^C exit: no stack trace noise
+signal.signal(signal.SIGINT, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+
+def _print_blocked_actions(pending_actions) -> None:
+    print(f"\n🔒 Security analyzer blocked {len(pending_actions)} high-risk action(s):")
+    for i, action in enumerate(pending_actions, start=1):
+        snippet = str(action.action)[:100].replace("\n", " ")
+        print(f"  {i}. {action.tool_name}: {snippet}...")
+
+
+def confirm_high_risk_in_console(pending_actions) -> bool:
+    """
+    Return True to approve, False to reject.
+    Matches original behavior: default to 'no' on EOF/KeyboardInterrupt.
+    """
+    _print_blocked_actions(pending_actions)
+    while True:
+        try:
+            ans = (
+                input(
+                    "\nThese actions were flagged as HIGH RISK. "
+                    "Do you want to execute them anyway? (yes/no): "
+                )
+                .strip()
+                .lower()
+            )
+        except (EOFError, KeyboardInterrupt):
+            print("\n❌ No input received; rejecting by default.")
+            return False
+
+        if ans in ("yes", "y"):
+            print("✅ Approved — executing high-risk actions...")
+            return True
+        if ans in ("no", "n"):
+            print("❌ Rejected — skipping high-risk actions...")
+            return False
+        print("Please enter 'yes' or 'no'.")
+
+
+def run_until_finished_with_security(
+    conversation: Conversation, confirmer: Callable[[list], bool]
+) -> None:
+    """
+    Drive the conversation until FINISHED.
+    - If WAITING_FOR_CONFIRMATION: ask the confirmer.
+        * On approve: set agent_status = IDLE (keeps original example’s behavior).
+        * On reject: conversation.reject_pending_actions(...).
+    - If WAITING but no pending actions: print warning and set IDLE (matches original).
+    """
+    while conversation.state.agent_status != AgentExecutionStatus.FINISHED:
+        if (
+            conversation.state.agent_status
+            == AgentExecutionStatus.WAITING_FOR_CONFIRMATION
+        ):
+            pending = get_unmatched_actions(conversation.state.events)
+            if not pending:
+                raise RuntimeError(
+                    "⚠️ Agent is waiting for confirmation but no pending actions "
+                    "were found. This should not happen."
+                )
+            if not confirmer(pending):
+                conversation.reject_pending_actions("User rejected high-risk actions")
+                continue
+
+        print("▶️  Running conversation.run()...")
+        conversation.run()
+
 
 # Configure LLM
 api_key = os.getenv("LITELLM_API_KEY")
@@ -37,10 +106,11 @@ tools = [
     ToolSpec(name="FileEditorTool"),
 ]
 
-# Create agent with security analyzer
+# Agent with security analyzer
 security_analyzer = LLMSecurityAnalyzer()
 agent = Agent(llm=llm, tools=tools, security_analyzer=security_analyzer)
 
+# Conversation with persisted filestore
 conversation_id = uuid.uuid4()
 file_store = LocalFileStore(f"./.conversations/{conversation_id}")
 conversation = Conversation(
@@ -53,75 +123,6 @@ conversation.run()
 
 print("\n2) Potentially risky command (may require confirmation)...")
 conversation.send_message(
-    "Create a temporary file called 'security_test.txt' -- THIS IS A HIGH RISK ACTION"
+    "Please echo 'hello world' -- PLEASE MARK THIS AS A HIGH RISK ACTION"
 )
-
-# Handle security analyzer blocking high-risk actions
-# Run conversation with security confirmation handling
-while conversation.state.agent_status != AgentExecutionStatus.FINISHED:
-    # Check if agent is waiting for confirmation due to security analyzer
-    if conversation.state.agent_status == AgentExecutionStatus.WAITING_FOR_CONFIRMATION:
-        pending_actions = get_unmatched_actions(conversation.state.events)
-
-        if pending_actions:
-            # Show the pending actions that were blocked
-            print(
-                f"\n🔒 Security analyzer blocked {len(pending_actions)} "
-                "high-risk action(s):"
-            )
-            for i, action in enumerate(pending_actions):
-                snippet = str(action.action)[:100].replace("\n", " ")
-                print(f"  {i + 1}. {action.tool_name}: {snippet}...")
-
-            # Ask the user if we should proceed or not
-            while True:
-                try:
-                    user_input = (
-                        input(
-                            "\nThese actions were flagged as HIGH RISK. "
-                            "Do you want to execute them anyway? (yes/no): "
-                        )
-                        .strip()
-                        .lower()
-                    )
-                except (EOFError, KeyboardInterrupt):
-                    print("\n❌ No input received; rejecting by default.")
-                    user_input = "no"
-                    break
-
-                if user_input in ("yes", "y"):
-                    print("✅ Approved — executing high-risk actions...")
-                    # If user wants to proceed, set agent state to idle
-                    conversation.state.agent_status = AgentExecutionStatus.IDLE
-                    break
-                elif user_input in ("no", "n"):
-                    print("❌ Rejected — skipping high-risk actions...")
-                    # If the user does not want to proceed, clear the pending actions
-                    conversation.reject_pending_actions(
-                        "User rejected high-risk actions"
-                    )
-                    break
-                else:
-                    print("Please enter 'yes' or 'no'.")
-
-            if user_input in ("no", "n"):
-                continue  # Loop continues — the agent may produce a new step or finish
-        else:
-            # Defensive: clear the flag if somehow set without actions
-            print(
-                "⚠️ Agent is waiting for confirmation but no pending actions were found."
-            )
-            conversation.state.agent_status = AgentExecutionStatus.IDLE
-
-    print("▶️  Running conversation.run()...")
-    conversation.run()
-
-print("\n3) Cleanup...")
-conversation.send_message("Remove any test files created")
-conversation.run()
-
-print("\n=== Example Complete ===")
-print("The LLMSecurityAnalyzer automatically evaluates action security risks.")
-print(
-    "HIGH risk actions require confirmation, while LOW risk actions execute directly."
-)
+run_until_finished_with_security(conversation, confirm_high_risk_in_console)

--- a/openhands/sdk/agent/agent.py
+++ b/openhands/sdk/agent/agent.py
@@ -174,6 +174,7 @@ class Agent(AgentBase):
                         model_name=self.llm.model, agent_name=self.name
                     )
                 },
+                add_security_risk_prediction=self._add_security_risk_prediction,
             )
         except Exception as e:
             # If there is a condenser registered and the exception is a context window

--- a/openhands/sdk/agent/agent.py
+++ b/openhands/sdk/agent/agent.py
@@ -30,6 +30,7 @@ from openhands.sdk.llm import (
     get_llm_metadata,
 )
 from openhands.sdk.logger import get_logger
+from openhands.sdk.security.confirmation_policy import NeverConfirm
 from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.tool import (
     ActionBase,
@@ -272,6 +273,17 @@ class Agent(AgentBase):
             2. Every action requires confirmation
             3. A single `FinishAction` never requires confirmation
         """
+        if self._add_security_risk_prediction and isinstance(
+            state.confirmation_policy, NeverConfirm
+        ):
+            # If security analyzer is enabled, we always need a policy that is not
+            # NeverConfirm, otherwise we are just predicting risks without using them,
+            # and waste tokens!
+            logger.warning(
+                "LLM security analyzer is enabled but confirmation "
+                "policy is set to NeverConfirm"
+            )
+
         # A single `FinishAction` never requires confirmation
         if len(action_events) == 1 and isinstance(
             action_events[0].action, FinishAction

--- a/openhands/sdk/agent/agent.py
+++ b/openhands/sdk/agent/agent.py
@@ -92,6 +92,18 @@ class Agent(AgentBase):
         # TODO(openhands): we should add test to test this init_state will actually
         # modify state in-place
 
+        # Validate security analyzer configuration once during initialization
+        if self._add_security_risk_prediction and isinstance(
+            state.confirmation_policy, NeverConfirm
+        ):
+            # If security analyzer is enabled, we always need a policy that is not
+            # NeverConfirm, otherwise we are just predicting risks without using them,
+            # and waste tokens!
+            logger.warning(
+                "LLM security analyzer is enabled but confirmation "
+                "policy is set to NeverConfirm"
+            )
+
         # Configure bash tools with env provider
         self._configure_bash_tools_env_provider(state)
 
@@ -273,17 +285,6 @@ class Agent(AgentBase):
             2. Every action requires confirmation
             3. A single `FinishAction` never requires confirmation
         """
-        if self._add_security_risk_prediction and isinstance(
-            state.confirmation_policy, NeverConfirm
-        ):
-            # If security analyzer is enabled, we always need a policy that is not
-            # NeverConfirm, otherwise we are just predicting risks without using them,
-            # and waste tokens!
-            logger.warning(
-                "LLM security analyzer is enabled but confirmation "
-                "policy is set to NeverConfirm"
-            )
-
         # A single `FinishAction` never requires confirmation
         if len(action_events) == 1 and isinstance(
             action_events[0].action, FinishAction

--- a/openhands/sdk/agent/base.py
+++ b/openhands/sdk/agent/base.py
@@ -155,7 +155,7 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         # Prepare template kwargs, including cli_mode if available
         template_kwargs = dict(self.system_prompt_kwargs)
         if self.security_analyzer:
-            template_kwargs["llm_risk_analyzer"] = bool(
+            template_kwargs["llm_security_analyzer"] = bool(
                 isinstance(self.security_analyzer, LLMSecurityAnalyzer)
             )
 

--- a/openhands/sdk/agent/base.py
+++ b/openhands/sdk/agent/base.py
@@ -13,6 +13,7 @@ from openhands.sdk.context.prompts.prompt import render_template
 from openhands.sdk.llm import LLM
 from openhands.sdk.logger import get_logger
 from openhands.sdk.mcp import create_mcp_tools
+from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.tool import BUILT_IN_TOOLS, Tool, ToolSpec, resolve_tool
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
 from openhands.sdk.utils.pydantic_diff import pretty_pydantic_diff
@@ -153,8 +154,10 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         """Compute system message on-demand to maintain statelessness."""
         # Prepare template kwargs, including cli_mode if available
         template_kwargs = dict(self.system_prompt_kwargs)
-        if hasattr(self, "cli_mode"):
-            template_kwargs["cli_mode"] = getattr(self, "cli_mode")
+        if self.security_analyzer:
+            template_kwargs["llm_risk_analyzer"] = bool(
+                isinstance(self.security_analyzer, LLMSecurityAnalyzer)
+            )
 
         system_message = render_template(
             prompt_dir=self.prompt_dir,

--- a/openhands/sdk/agent/prompts/security_risk_assessment.j2
+++ b/openhands/sdk/agent/prompts/security_risk_assessment.j2
@@ -8,7 +8,6 @@ When using tools that support the security_risk parameter, assess the safety ris
   - Modify user project files, run project scripts/tests, install project-local packages.
 - **HIGH**: System-level or untrusted operations.
   - Changing system settings, global installs, elevated (`sudo`) commands, deleting critical files, downloading & executing untrusted code, or sending local secrets/data out.
-
 {% else %}
 - **LOW**: Read-only actions inside sandbox.
   - Inspecting container files, calculations, viewing docs.
@@ -16,7 +15,6 @@ When using tools that support the security_risk parameter, assess the safety ris
   - Modify workspace files, install packages system-wide inside container, run user code.
 - **HIGH**: Data exfiltration or privilege breaks.
   - Sending secrets/local data out, connecting to host filesystem, privileged container ops, running unverified binaries with network access.
-
 {% endif %}
 
 **Global Rules**

--- a/openhands/sdk/agent/prompts/system_prompt.j2
+++ b/openhands/sdk/agent/prompts/system_prompt.j2
@@ -65,9 +65,11 @@ Your primary role is to assist users by executing commands, modifying code, and 
 {% include 'security_policy.j2' %}
 </SECURITY>
 
+{% if llm_risk_analyzer %}
 <SECURITY_RISK_ASSESSMENT>
 {% include 'security_risk_assessment.j2' %}
 </SECURITY_RISK_ASSESSMENT>
+{% endif %}
 
 <EXTERNAL_SERVICES>
 * When interacting with external services like GitHub, GitLab, or Bitbucket, use their respective APIs instead of browser-based interactions whenever possible.

--- a/openhands/sdk/agent/prompts/system_prompt.j2
+++ b/openhands/sdk/agent/prompts/system_prompt.j2
@@ -65,7 +65,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 {% include 'security_policy.j2' %}
 </SECURITY>
 
-{% if llm_risk_analyzer %}
+{% if llm_security_analyzer %}
 <SECURITY_RISK_ASSESSMENT>
 {% include 'security_risk_assessment.j2' %}
 </SECURITY_RISK_ASSESSMENT>

--- a/openhands/sdk/event/llm_convertible/action.py
+++ b/openhands/sdk/event/llm_convertible/action.py
@@ -63,6 +63,16 @@ class ActionEvent(LLMConvertibleEvent):
         """Return Rich Text representation of this action event."""
         content = Text()
 
+        if self.security_risk != risk.SecurityRisk.UNKNOWN:
+            color = {
+                risk.SecurityRisk.LOW: "green",
+                risk.SecurityRisk.MEDIUM: "yellow",
+                risk.SecurityRisk.HIGH: "red",
+            }.get(self.security_risk, "white")
+            content.append(
+                f"[Predicted Security Risk: {self.security_risk.value}]\n", style=color
+            )
+
         # Display reasoning content first if available
         if self.reasoning_content:
             content.append("Reasoning:\n", style="bold")

--- a/openhands/sdk/event/llm_convertible/action.py
+++ b/openhands/sdk/event/llm_convertible/action.py
@@ -64,14 +64,7 @@ class ActionEvent(LLMConvertibleEvent):
         content = Text()
 
         if self.security_risk != risk.SecurityRisk.UNKNOWN:
-            content.append(
-                "Predicted Security Risk: ",
-                style="bold",
-            )
-            content.append(
-                f"{self.security_risk.value}\n\n",
-                style=f"bold {self.security_risk.get_color()}",
-            )
+            content.append(self.security_risk.visualize)
 
         # Display reasoning content first if available
         if self.reasoning_content:

--- a/openhands/sdk/event/llm_convertible/action.py
+++ b/openhands/sdk/event/llm_convertible/action.py
@@ -70,8 +70,10 @@ class ActionEvent(LLMConvertibleEvent):
                 risk.SecurityRisk.HIGH: "red",
             }.get(self.security_risk, "white")
             content.append(
-                f"[Predicted Security Risk: {self.security_risk.value}]\n", style=color
+                "Predicted Security Risk: ",
+                style="bold",
             )
+            content.append(f"{self.security_risk.value}\n\n", style=f"bold {color}")
 
         # Display reasoning content first if available
         if self.reasoning_content:

--- a/openhands/sdk/event/llm_convertible/action.py
+++ b/openhands/sdk/event/llm_convertible/action.py
@@ -64,16 +64,14 @@ class ActionEvent(LLMConvertibleEvent):
         content = Text()
 
         if self.security_risk != risk.SecurityRisk.UNKNOWN:
-            color = {
-                risk.SecurityRisk.LOW: "green",
-                risk.SecurityRisk.MEDIUM: "yellow",
-                risk.SecurityRisk.HIGH: "red",
-            }.get(self.security_risk, "white")
             content.append(
                 "Predicted Security Risk: ",
                 style="bold",
             )
-            content.append(f"{self.security_risk.value}\n\n", style=f"bold {color}")
+            content.append(
+                f"{self.security_risk.value}\n\n",
+                style=f"bold {self.security_risk.get_color()}",
+            )
 
         # Display reasoning content first if available
         if self.reasoning_content:

--- a/openhands/sdk/security/risk.py
+++ b/openhands/sdk/security/risk.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from enum import Enum
 
+from rich.text import Text
+
 
 class SecurityRisk(str, Enum):
     """Security risk levels for actions.
@@ -44,6 +46,20 @@ class SecurityRisk(str, Enum):
             SecurityRisk.UNKNOWN: "white",
         }
         return color_map.get(self, "white")
+
+    @property
+    def visualize(self) -> Text:
+        """Return Rich Text representation of this risk level."""
+        content = Text()
+        content.append(
+            "Predicted Security Risk: ",
+            style="bold",
+        )
+        content.append(
+            f"{self.value}\n\n",
+            style=f"bold {self.get_color()}",
+        )
+        return content
 
     def is_riskier(self, other: SecurityRisk, reflexive: bool = True) -> bool:
         """Check if this risk level is riskier than another.

--- a/openhands/sdk/security/risk.py
+++ b/openhands/sdk/security/risk.py
@@ -35,6 +35,16 @@ class SecurityRisk(str, Enum):
     def __str__(self) -> str:
         return self.name
 
+    def get_color(self) -> str:
+        """Get the color for displaying this risk level in Rich text."""
+        color_map = {
+            SecurityRisk.LOW: "green",
+            SecurityRisk.MEDIUM: "yellow",
+            SecurityRisk.HIGH: "red",
+            SecurityRisk.UNKNOWN: "white",
+        }
+        return color_map.get(self, "white")
+
     def is_riskier(self, other: SecurityRisk, reflexive: bool = True) -> bool:
         """Check if this risk level is riskier than another.
 

--- a/openhands/sdk/tool/tool.py
+++ b/openhands/sdk/tool/tool.py
@@ -287,7 +287,8 @@ def _create_action_type_with_risk(action_type: type[ActionBase]) -> type[ActionB
         (action_type,),
         {
             "security_risk": Field(
-                default=risk.SecurityRisk.UNKNOWN,
+                # We do NOT add default value to make it an required field
+                # default=risk.SecurityRisk.UNKNOWN
                 description="The LLM's assessment of the safety risk of this action.",
             ),
             "__annotations__": {"security_risk": risk.SecurityRisk},

--- a/tests/sdk/agent/test_agent_immutability.py
+++ b/tests/sdk/agent/test_agent_immutability.py
@@ -5,6 +5,7 @@ from pydantic import SecretStr, ValidationError
 
 from openhands.sdk.agent.agent import Agent
 from openhands.sdk.llm import LLM
+from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 
 
 class TestAgentImmutability:
@@ -54,8 +55,21 @@ class TestAgentImmutability:
 
     def test_agent_with_different_configs_are_different(self):
         """Test that agents with different configs produce different system messages."""
-        agent1 = Agent(llm=self.llm, tools=[], system_prompt_kwargs={"cli_mode": True})
-        agent2 = Agent(llm=self.llm, tools=[], system_prompt_kwargs={"cli_mode": False})
+        # Use LLMSecurityAnalyzer so that the security risk assessment section is
+        # included and cli_mode differences will be visible in the system message
+        security_analyzer = LLMSecurityAnalyzer()
+        agent1 = Agent(
+            llm=self.llm,
+            tools=[],
+            security_analyzer=security_analyzer,
+            system_prompt_kwargs={"cli_mode": True},
+        )
+        agent2 = Agent(
+            llm=self.llm,
+            tools=[],
+            security_analyzer=security_analyzer,
+            system_prompt_kwargs={"cli_mode": False},
+        )
 
         # System messages should be different due to cli_mode
         msg1 = agent1.system_message
@@ -135,8 +149,14 @@ class TestAgentImmutability:
 
     def test_agent_model_copy_creates_new_instance(self):
         """Test that model_copy creates a new Agent instance with modified fields."""
+        # Use LLMSecurityAnalyzer so that the security risk assessment section is
+        # included and cli_mode differences will be visible in the system message
+        security_analyzer = LLMSecurityAnalyzer()
         original_agent = Agent(
-            llm=self.llm, tools=[], system_prompt_kwargs={"cli_mode": True}
+            llm=self.llm,
+            tools=[],
+            security_analyzer=security_analyzer,
+            system_prompt_kwargs={"cli_mode": True},
         )
 
         # Create a copy with modified fields

--- a/tests/sdk/security/test_security_risk.py
+++ b/tests/sdk/security/test_security_risk.py
@@ -74,3 +74,11 @@ def test_riskiness_ordering_undefined_for_unknown():
         else:
             comparison = first_risk.is_riskier(second_risk)
             assert comparison in (True, False)
+
+
+def test_security_risk_get_color():
+    """Test that SecurityRisk.get_color() returns expected color codes."""
+    assert SecurityRisk.LOW.get_color() == "green"
+    assert SecurityRisk.MEDIUM.get_color() == "yellow"
+    assert SecurityRisk.HIGH.get_color() == "red"
+    assert SecurityRisk.UNKNOWN.get_color() == "white"


### PR DESCRIPTION
- Do not include the LLM risk analyzer-related system prompt when the LLM Security Analyzer is not enabled
- Fix security analyzer example with the latest confirmation policy change
- Fix to make sure `security_risk` is a required field when converting it to LLM tool