### PR TITLE
Add OpenAI Responses API support for GPT-5 and reasoning models

### DIFF
--- a/openhands/sdk/__init__.py
+++ b/openhands/sdk/__init__.py
@@ -19,6 +19,7 @@ from openhands.sdk.llm import (
     LLMRegistry,
     Message,
     RegistryEvent,
+    ResponsesAPIResponse,
     TextContent,
 )
 from openhands.sdk.logger import get_logger
@@ -47,6 +48,7 @@ __all__ = [
     "Message",
     "TextContent",
     "ImageContent",
+    "ResponsesAPIResponse",
     "Tool",
     "ToolBase",
     "ToolSpec",

--- a/openhands/sdk/llm/__init__.py
+++ b/openhands/sdk/llm/__init__.py
@@ -1,11 +1,6 @@
+from litellm.types.llms.openai import ResponsesAPIResponse
+
 from openhands.sdk.llm.llm import LLM
-
-
-# Import ResponsesAPIResponse if available
-try:
-    from litellm.types.llms.openai import ResponsesAPIResponse
-except ImportError:
-    ResponsesAPIResponse = None
 from openhands.sdk.llm.llm_registry import LLMRegistry, RegistryEvent
 from openhands.sdk.llm.message import ImageContent, Message, TextContent, content_to_str
 from openhands.sdk.llm.metadata import get_llm_metadata

--- a/openhands/sdk/llm/__init__.py
+++ b/openhands/sdk/llm/__init__.py
@@ -1,4 +1,11 @@
 from openhands.sdk.llm.llm import LLM
+
+
+# Import ResponsesAPIResponse if available
+try:
+    from litellm.types.llms.openai import ResponsesAPIResponse
+except ImportError:
+    ResponsesAPIResponse = None
 from openhands.sdk.llm.llm_registry import LLMRegistry, RegistryEvent
 from openhands.sdk.llm.message import ImageContent, Message, TextContent, content_to_str
 from openhands.sdk.llm.metadata import get_llm_metadata
@@ -26,4 +33,5 @@ __all__ = [
     "VERIFIED_MODELS",
     "UNVERIFIED_MODELS_EXCLUDING_BEDROCK",
     "get_unverified_models",
+    "ResponsesAPIResponse",
 ]

--- a/tests/sdk/llm/test_responses_api.py
+++ b/tests/sdk/llm/test_responses_api.py
@@ -1,0 +1,170 @@
+"""Tests for OpenAI Responses API support in LLM class."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.sdk.llm import LLM
+
+
+class TestResponsesAPI:
+    """Test cases for the responses API functionality."""
+
+    def test_responses_api_available_import(self):
+        """Test that responses API imports are handled gracefully."""
+        # This test ensures the import doesn't fail even if litellm doesn't have
+        # responses API
+        llm = LLM(model="gpt-3.5-turbo", api_key=SecretStr("test-key"))
+        assert hasattr(llm, "responses")
+
+    def test_responses_method_signature(self):
+        """Test that the responses method has the correct signature."""
+        llm = LLM(model="gpt-3.5-turbo", api_key=SecretStr("test-key"))
+
+        # Check method exists and has correct parameters
+        assert hasattr(llm, "responses")
+        assert callable(llm.responses)
+
+    @patch("openhands.sdk.llm.llm.RESPONSES_API_AVAILABLE", True)
+    @patch("openhands.sdk.llm.llm.litellm_responses")
+    def test_responses_api_call_basic(self, mock_litellm_responses):
+        """Test basic responses API call."""
+        # Mock the response
+        mock_response = Mock()
+        mock_response.output = [Mock(content="Hello, World!", type="text")]
+        mock_response.id = "test-response-id"
+        mock_response.usage = Mock(total_tokens=10)
+        mock_litellm_responses.return_value = mock_response
+
+        llm = LLM(model="gpt-5", api_key=SecretStr("test-key"))
+
+        response = llm.responses(
+            input_text="Hello, world!",
+            instructions="You are a helpful assistant.",
+            max_output_tokens=100,
+        )
+
+        # Verify the call was made
+        mock_litellm_responses.assert_called_once()
+        call_args = mock_litellm_responses.call_args[1]
+
+        assert call_args["input"] == "Hello, world!"
+        assert call_args["model"] == "gpt-5"
+        assert call_args["instructions"] == "You are a helpful assistant."
+        assert call_args["max_output_tokens"] == 100
+        assert call_args["api_key"] == "test-key"
+
+        # Verify response
+        assert response == mock_response
+
+    @patch("openhands.sdk.llm.llm.RESPONSES_API_AVAILABLE", True)
+    @patch("openhands.sdk.llm.llm.litellm_responses")
+    def test_responses_api_with_tools(self, mock_litellm_responses):
+        """Test responses API call with tools."""
+        # Mock the response
+        mock_response = Mock()
+        mock_response.output = [Mock(content="Used tool", type="text")]
+        mock_litellm_responses.return_value = mock_response
+
+        # Mock tool
+        mock_tool = Mock()
+        mock_tool.to_openai_tool.return_value = {
+            "type": "function",
+            "function": {"name": "test_tool"},
+        }
+
+        llm = LLM(model="gpt-5", api_key=SecretStr("test-key"))
+
+        llm.responses(input_text="Use the tool", tools=[mock_tool])
+
+        # Verify the call was made with tools
+        mock_litellm_responses.assert_called_once()
+        call_args = mock_litellm_responses.call_args[1]
+
+        assert call_args["tools"] == [
+            {"type": "function", "function": {"name": "test_tool"}}
+        ]
+        mock_tool.to_openai_tool.assert_called_once()
+
+    @patch("openhands.sdk.llm.llm.RESPONSES_API_AVAILABLE", True)
+    @patch("openhands.sdk.llm.llm.litellm_responses")
+    def test_responses_api_temperature_handling(self, mock_litellm_responses):
+        """Test that temperature is handled correctly for different models."""
+        # Mock the response
+        mock_response = Mock()
+        mock_response.output = [Mock(content="Response", type="text")]
+        mock_litellm_responses.return_value = mock_response
+
+        # Test with GPT-5 (default temperature 0.0 should not be passed)
+        llm = LLM(model="gpt-5", api_key=SecretStr("test-key"))
+
+        llm.responses(input_text="Test")
+
+        call_args = mock_litellm_responses.call_args[1]
+        assert "temperature" not in call_args
+
+        # Test with explicit temperature
+        mock_litellm_responses.reset_mock()
+        llm.responses(input_text="Test", temperature=0.7)
+
+        call_args = mock_litellm_responses.call_args[1]
+        assert call_args["temperature"] == 0.7
+
+    @patch("openhands.sdk.llm.llm.RESPONSES_API_AVAILABLE", False)
+    def test_responses_api_not_available(self):
+        """Test error when responses API is not available."""
+        llm = LLM(model="gpt-5", api_key=SecretStr("test-key"))
+
+        with pytest.raises(ValueError, match="Responses API is not available"):
+            llm.responses(input_text="Test")
+
+    @patch("openhands.sdk.llm.llm.RESPONSES_API_AVAILABLE", True)
+    def test_responses_api_streaming_not_supported(self):
+        """Test that streaming raises an error."""
+        llm = LLM(model="gpt-5", api_key=SecretStr("test-key"))
+
+        with pytest.raises(ValueError, match="Streaming is not supported"):
+            llm.responses(input_text="Test", stream=True)
+
+    @patch("openhands.sdk.llm.llm.RESPONSES_API_AVAILABLE", True)
+    @patch("openhands.sdk.llm.llm.litellm_responses")
+    def test_responses_api_empty_response_error(self, mock_litellm_responses):
+        """Test error handling for empty responses."""
+        from openhands.sdk.llm.llm import LLMNoResponseError
+
+        # Mock empty response
+        mock_litellm_responses.return_value = None
+
+        llm = LLM(model="gpt-5", api_key=SecretStr("test-key"))
+
+        with pytest.raises(LLMNoResponseError, match="Response is empty"):
+            llm.responses(input_text="Test")
+
+    @patch("openhands.sdk.llm.llm.RESPONSES_API_AVAILABLE", True)
+    @patch("openhands.sdk.llm.llm.litellm_responses")
+    def test_responses_api_parameter_filtering(self, mock_litellm_responses):
+        """Test that None parameters are filtered out."""
+        # Mock the response
+        mock_response = Mock()
+        mock_response.output = [Mock(content="Response", type="text")]
+        mock_litellm_responses.return_value = mock_response
+
+        llm = LLM(model="gpt-5", api_key=SecretStr("test-key"))
+
+        llm.responses(
+            input_text="Test",
+            tools=None,
+            instructions=None,
+            max_output_tokens=None,
+            temperature=None,
+        )
+
+        call_args = mock_litellm_responses.call_args[1]
+
+        # None values should be filtered out
+        assert "tools" not in call_args
+        assert "instructions" not in call_args
+        assert "temperature" not in call_args
+        # max_output_tokens should use default from LLM instance
+        assert "max_output_tokens" in call_args


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for OpenAI's Responses API to the agent SDK, enabling the use of GPT-5, GPT-5-codex, and other reasoning models that require the responses API.

## Key Features

### 1. Direct Responses API Support
- Added `responses()` method to the LLM class with proper parameter handling
- Imported `ResponsesAPIResponse` type and `litellm.responses` function with fallback handling
- Exported `ResponsesAPIResponse` type in SDK modules for external use
- Handles temperature parameter filtering for models that don't support it (like GPT-5)

### 2. Automatic Fallback Mechanism
- **Seamless Integration**: When completion API fails with "only supported in v1/responses" error, automatically falls back to responses API
- **Transparent Operation**: No changes required to existing agent code - GPT-5-codex works out of the box
- **Response Conversion**: Automatically converts `ResponsesAPIResponse` to `ModelResponse` format for compatibility
- **Message Handling**: Properly handles both string and list content formats in message conversion

### 3. Comprehensive Testing
- Added 9 unit tests covering all responses API functionality
- Tests parameter filtering, error handling, streaming restrictions, and edge cases
- All existing tests continue to pass (316/316)

## Tested Models

✅ **GPT-5**: Works with responses API  
✅ **GPT-5-codex**: Works with automatic fallback (responses-only model)  
✅ **Existing models**: Continue to work with completion API  

## Usage Examples

### Direct Responses API Usage
```python
from openhands.sdk import LLM
from pydantic import SecretStr

llm = LLM(model="gpt-5", api_key=SecretStr("your-key"))
response = llm.responses(
    input_text="Write a Python function",
    instructions="You are a helpful coding assistant"
)
```

### Automatic Fallback (GPT-5-codex)
```python
# This now works automatically - no code changes needed!
llm = LLM(model="openai/gpt-5-codex", api_key=SecretStr("your-key"))
response = llm.completion(messages=[...])  # Automatically uses responses API
```

## Implementation Details

- **Backward Compatibility**: All existing functionality preserved
- **Error Handling**: Graceful fallback with informative logging
- **Type Safety**: Proper type annotations and response conversion
- **Performance**: Minimal overhead - fallback only triggered when needed

## Testing

```bash
# Run all LLM tests
uv run pytest tests/sdk/llm/ -v

# Run responses API specific tests  
uv run pytest tests/sdk/llm/test_responses_api.py -v
```

This enables the agent SDK to work with OpenAI's latest reasoning models while maintaining full backward compatibility with existing code.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/43299d2d426c479caee2ef95eceb28fe)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:73e9e7a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-73e9e7a-python \
  ghcr.io/all-hands-ai/agent-server:73e9e7a-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:73e9e7a-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:73e9e7a-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:73e9e7a-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `73e9e7a` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->