### PR TITLE
chore(ruff): enforce Python 3.12 typing standards with UP006, UP007, …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ quote-style = "double"
 indent-style = "space"
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "UP006", "UP007", "UP035", "UP045"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["openhands"]


### PR DESCRIPTION
…UP035, UP045

- UP006: Use dict/list instead of Dict/List for type annotations
- UP007: Use X | Y for union types instead of Union[X, Y]
- UP035: Import from typing is deprecated, use builtin types
- UP045: Use X | None instead of Optional[X]

This prevents regression back to old typing patterns and enforces the modernization standards described in this PR.