### PR TITLE
Fix #470: Update PR description instead of creating comments for agent server images

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -205,26 +205,26 @@ jobs:
             - name: Update PR description with docker command
               uses: nefrob/pr-description@v1.2.0
               with:
-                  content: |2
+                  content: |
 
-                          ---
+                      ---
 
-                          **Agent Server image for this PR**
+                      **Agent Server image for this PR**
 
-                          Pull (multi-arch manifest):
-                          ```bash
-                          docker pull ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
-                          ```
+                      Pull (multi-arch manifest):
+                      ```bash
+                      docker pull ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
+                      ```
 
-                          Run:
-                          ```bash
-                          docker run -it --rm \
-                            -p 8000:8000 \
-                            --name agent-server-${{ env.SHORT_SHA }} \
-                            ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
-                          ```
+                      Run:
+                      ```bash
+                      docker run -it --rm \
+                        -p 8000:8000 \
+                        --name agent-server-${{ env.SHORT_SHA }} \
+                        ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
+                      ```
 
-                          _This tag is a multi-arch manifest (amd64/arm64). Your client pulls the right arch automatically._
+                      _This tag is a multi-arch manifest (amd64/arm64). Your client pulls the right arch automatically._
                   regex: "---\\s*\\*\\*Agent Server image for this PR\\*\\*[\\s\\S]*?(?=\\n\\n---|\n\\n##|$)"
                   regexFlags: m
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -205,25 +205,26 @@ jobs:
             - name: Update PR description with docker command
               uses: nefrob/pr-description@v1.2.0
               with:
-                  content: |
-                      ---
+                  content: |2
 
-                      **Agent Server image for this PR**
+                          ---
 
-                      Pull (multi-arch manifest):
-                      ```bash
-                      docker pull ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
-                      ```
+                          **Agent Server image for this PR**
 
-                      Run:
-                      ```bash
-                      docker run -it --rm \
-                        -p 8000:8000 \
-                        --name agent-server-${{ env.SHORT_SHA }} \
-                        ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
-                      ```
+                          Pull (multi-arch manifest):
+                          ```bash
+                          docker pull ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
+                          ```
 
-                      _This tag is a multi-arch manifest (amd64/arm64). Your client pulls the right arch automatically._
+                          Run:
+                          ```bash
+                          docker run -it --rm \
+                            -p 8000:8000 \
+                            --name agent-server-${{ env.SHORT_SHA }} \
+                            ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
+                          ```
+
+                          _This tag is a multi-arch manifest (amd64/arm64). Your client pulls the right arch automatically._
                   regex: "---\\s*\\*\\*Agent Server image for this PR\\*\\*[\\s\\S]*?(?=\\n\\n---|\n\\n##|$)"
                   regexFlags: m
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -188,8 +188,8 @@ jobs:
                   echo "Multiline tags:"
                   echo "${{ steps.build.outputs.tags }}"
 
-    post-image-comment:
-        name: Post/Update PR image comment
+    update-pr-description:
+        name: Update PR description with agent server image
         needs: build-and-push-image
         # Only on PRs, and only if the build actually ran and succeeded
         if: github.event_name == 'pull_request' && needs.build-and-push-image.result == 'success'
@@ -202,12 +202,12 @@ jobs:
             SHORT_SHA: ${{ needs.build-and-push-image.outputs.short_sha }}
 
         steps:
-            - name: Sticky PR comment with docker command
-              uses: marocchino/sticky-pull-request-comment@v2
+            - name: Update PR description with docker command
+              uses: nefrob/pr-description@v1.2.0
               with:
-                  header: agent-server-image
-                  recreate: true
-                  message: |
+                  content: |
+                      ---
+
                       **Agent Server image for this PR**
 
                       Pull (multi-arch manifest):
@@ -224,3 +224,6 @@ jobs:
                       ```
 
                       _This tag is a multi-arch manifest (amd64/arm64). Your client pulls the right arch automatically._
+                  regex: "---\\s*\\*\\*Agent Server image for this PR\\*\\*[\\s\\S]*?(?=\\n\\n---|\n\\n##|$)"
+                  regexFlags: m
+                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -205,26 +205,9 @@ jobs:
             - name: Update PR description with docker command
               uses: nefrob/pr-description@v1.2.0
               with:
-                  content: |
-
-                      ---
-
-                      **Agent Server image for this PR**
-
-                      Pull (multi-arch manifest):
-                      ```bash
-                      docker pull ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
-                      ```
-
-                      Run:
-                      ```bash
-                      docker run -it --rm \
-                        -p 8000:8000 \
-                        --name agent-server-${{ env.SHORT_SHA }} \
-                        ${{ env.IMAGE }}:${{ env.SHORT_SHA }}
-                      ```
-
-                      _This tag is a multi-arch manifest (amd64/arm64). Your client pulls the right arch automatically._
+                  content: "\n---\n\n**Agent Server image for this PR**\n\nPull (multi-arch manifest):\n```bash\ndocker pull ${{ env.IMAGE }}:${{ env.SHORT_SHA
+                      }}\n```\n\nRun:\n```bash\ndocker run -it --rm \\\n  -p 8000:8000 \\\n  --name agent-server-${{ env.SHORT_SHA }} \\\n  ${{ env.IMAGE
+                      }}:${{ env.SHORT_SHA }}\n```\n\n_This tag is a multi-arch manifest (amd64/arm64). Your client pulls the right arch automatically._"
                   regex: "---\\s*\\*\\*Agent Server image for this PR\\*\\*[\\s\\S]*?(?=\\n\\n---|\n\\n##|$)"
                   regexFlags: m
                   token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR fixes issue #470 by replacing the noisy comment mechanism with PR description updates for agent server image information.

## Changes

- **Replaced `marocchino/sticky-pull-request-comment@v2`** with `nefrob/pr-description@v1.2.0`
- **Updated job name** from `post-image-comment` to `update-pr-description` 
- **Modified the workflow** to append agent server image information to the PR description instead of creating new comments
- **Added regex pattern** to match and replace existing agent server image sections in PR descriptions

## Benefits

- **Reduces email notification noise** - No more comment notifications for every Docker image build
- **Cleaner PR interface** - Agent server information is part of the PR description rather than cluttering the comment section
- **Persistent information** - The agent server image details remain visible in the PR description without scrolling through comments

## Technical Details

The new implementation uses a regex pattern to match and replace any existing "Agent Server image for this PR" section in the PR description. If no existing section is found, it will append the information to the end of the description.

The regex pattern used: `---\\s*\\*\\*Agent Server image for this PR\\*\\*[\\s\\S]*?(?=\\n\\n---|\n\\n##|$)`

This ensures that:
1. Multiple builds on the same PR update the same section instead of creating duplicates
2. The information is clearly separated with horizontal rules (`---`)
3. The section can be easily identified and replaced in subsequent builds

## Testing

The workflow will be tested when this PR is created, as it triggers the `pull_request` event that runs the modified `update-pr-description` job.

Fixes #470

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9ab1cad2090049d2af13665cc0d39c05)
      

---

**Agent Server image for this PR**

Pull (multi-arch manifest):
```bash
docker pull ghcr.io/all-hands-ai/agent-server:9e0a7b0
```

Run:
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9e0a7b0 \
  ghcr.io/all-hands-ai/agent-server:9e0a7b0
```

_This tag is a multi-arch manifest (amd64/arm64). Your client pulls the right arch automatically._