### PR TITLE
Refactor LLM registry to remove service_id parameter from add() method

### DIFF
--- a/examples/01_hello_world.py
+++ b/examples/01_hello_world.py
@@ -21,6 +21,7 @@ llm = LLM(
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
+    service_id="hello-world-llm",
 )
 
 cwd = os.getcwd()

--- a/examples/02_custom_tools.py
+++ b/examples/02_custom_tools.py
@@ -119,6 +119,7 @@ _GREP_DESCRIPTION = """Fast content search tool.
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/02_custom_tools.py
+++ b/examples/02_custom_tools.py
@@ -119,7 +119,7 @@ _GREP_DESCRIPTION = """Fast content search tool.
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/03_activate_microagent.py
+++ b/examples/03_activate_microagent.py
@@ -26,6 +26,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/03_activate_microagent.py
+++ b/examples/03_activate_microagent.py
@@ -26,7 +26,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/04_confirmation_mode_example.py
+++ b/examples/04_confirmation_mode_example.py
@@ -81,6 +81,7 @@ def run_until_finished(conversation: BaseConversation, confirmer: Callable) -> N
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/04_confirmation_mode_example.py
+++ b/examples/04_confirmation_mode_example.py
@@ -81,7 +81,7 @@ def run_until_finished(conversation: BaseConversation, confirmer: Callable) -> N
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/05_use_llm_registry.py
+++ b/examples/05_use_llm_registry.py
@@ -25,6 +25,7 @@ assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 # Create LLM instance
 main_llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
@@ -32,7 +33,7 @@ main_llm = LLM(
 
 # Create LLM registry and add the LLM
 llm_registry = LLMRegistry()
-llm_registry.add("main_agent", main_llm)
+llm_registry.add(main_llm)
 
 # Get LLM from registry
 llm = llm_registry.get("main_agent")

--- a/examples/05_use_llm_registry.py
+++ b/examples/05_use_llm_registry.py
@@ -25,7 +25,7 @@ assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 # Create LLM instance
 main_llm = LLM(
-    service_id="test-llm",
+    service_id="primary-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/06_interactive_terminal_w_reasoning.py
+++ b/examples/06_interactive_terminal_w_reasoning.py
@@ -20,6 +20,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     # model="litellm_proxy/gemini/gemini-2.5-pro",
     model="litellm_proxy/deepseek/deepseek-reasoner",
     base_url="https://llm-proxy.eval.all-hands.dev",

--- a/examples/06_interactive_terminal_w_reasoning.py
+++ b/examples/06_interactive_terminal_w_reasoning.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     # model="litellm_proxy/gemini/gemini-2.5-pro",
     model="litellm_proxy/deepseek/deepseek-reasoner",
     base_url="https://llm-proxy.eval.all-hands.dev",

--- a/examples/07_mcp_integration.py
+++ b/examples/07_mcp_integration.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/07_mcp_integration.py
+++ b/examples/07_mcp_integration.py
@@ -21,6 +21,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/08_mcp_with_oauth.py
+++ b/examples/08_mcp_with_oauth.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/08_mcp_with_oauth.py
+++ b/examples/08_mcp_with_oauth.py
@@ -21,6 +21,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/09_pause_example.py
+++ b/examples/09_pause_example.py
@@ -19,7 +19,7 @@ from openhands.tools.str_replace_editor import FileEditorTool
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/09_pause_example.py
+++ b/examples/09_pause_example.py
@@ -19,6 +19,7 @@ from openhands.tools.str_replace_editor import FileEditorTool
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/10_persistence.py
+++ b/examples/10_persistence.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/10_persistence.py
+++ b/examples/10_persistence.py
@@ -23,6 +23,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/11_async.py
+++ b/examples/11_async.py
@@ -31,6 +31,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/11_async.py
+++ b/examples/11_async.py
@@ -31,7 +31,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/12_custom_secrets.py
+++ b/examples/12_custom_secrets.py
@@ -16,7 +16,7 @@ from openhands.tools.str_replace_editor import FileEditorTool
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="claude-sonnet-4-20250514",
     api_key=SecretStr(api_key),
 )

--- a/examples/12_custom_secrets.py
+++ b/examples/12_custom_secrets.py
@@ -16,6 +16,7 @@ from openhands.tools.str_replace_editor import FileEditorTool
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="claude-sonnet-4-20250514",
     api_key=SecretStr(api_key),
 )

--- a/examples/13_get_llm_metrics.py
+++ b/examples/13_get_llm_metrics.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/13_get_llm_metrics.py
+++ b/examples/13_get_llm_metrics.py
@@ -21,6 +21,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/14_context_condenser.py
+++ b/examples/14_context_condenser.py
@@ -31,6 +31,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/14_context_condenser.py
+++ b/examples/14_context_condenser.py
@@ -31,7 +31,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/15_browser_use.py
+++ b/examples/15_browser_use.py
@@ -22,6 +22,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/15_browser_use.py
+++ b/examples/15_browser_use.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/16_llm_security_analyzer.py
+++ b/examples/16_llm_security_analyzer.py
@@ -94,6 +94,7 @@ def run_until_finished_with_security(
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/16_llm_security_analyzer.py
+++ b/examples/16_llm_security_analyzer.py
@@ -94,7 +94,7 @@ def run_until_finished_with_security(
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="security-analyzer",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/17_image_input.py
+++ b/examples/17_image_input.py
@@ -32,7 +32,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="vision-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/17_image_input.py
+++ b/examples/17_image_input.py
@@ -32,6 +32,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/18_send_message_while_processing.py
+++ b/examples/18_send_message_while_processing.py
@@ -59,6 +59,7 @@ from openhands.tools.str_replace_editor import FileEditorTool
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/18_send_message_while_processing.py
+++ b/examples/18_send_message_while_processing.py
@@ -59,7 +59,7 @@ from openhands.tools.str_replace_editor import FileEditorTool
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/19_llm_routing.py
+++ b/examples/19_llm_routing.py
@@ -24,13 +24,13 @@ api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 primary_llm = LLM(
-    service_id="test-llm",
+    service_id="primary-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
 )
 secondary_llm = LLM(
-    service_id="test-llm",
+    service_id="secondary-llm",
     model="litellm_proxy/mistral/devstral-small-2507",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/19_llm_routing.py
+++ b/examples/19_llm_routing.py
@@ -24,16 +24,19 @@ api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 primary_llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
 )
 secondary_llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/mistral/devstral-small-2507",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
 )
 multimodal_router = MultimodalRouter(
+    service_id="multimodal-router",
     llms_for_routing={"primary": primary_llm, "secondary": secondary_llm},
 )
 

--- a/examples/20_stuck_detector.py
+++ b/examples/20_stuck_detector.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/20_stuck_detector.py
+++ b/examples/20_stuck_detector.py
@@ -18,6 +18,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/21_generate_extraneous_conversation_costs.py
+++ b/examples/21_generate_extraneous_conversation_costs.py
@@ -27,6 +27,7 @@ assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 # Create LLM instance
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
@@ -65,11 +66,12 @@ conversation.run()
 
 # Demonstrate extraneous costs part of the conversation
 second_llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
 )
-conversation.llm_registry.add("extraneous service", second_llm)
+conversation.llm_registry.add(second_llm)
 completion_response = second_llm.completion(
     messages=[Message(role="user", content=[TextContent(text="echo 'More spend!'")])]
 )

--- a/examples/21_generate_extraneous_conversation_costs.py
+++ b/examples/21_generate_extraneous_conversation_costs.py
@@ -27,7 +27,7 @@ assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 # Create LLM instance
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
@@ -66,7 +66,7 @@ conversation.run()
 
 # Demonstrate extraneous costs part of the conversation
 second_llm = LLM(
-    service_id="test-llm",
+    service_id="secondary-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/22_hello_world_with_agent_server.py
+++ b/examples/22_hello_world_with_agent_server.py
@@ -122,6 +122,7 @@ api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 llm = LLM(
+    service_id="test-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/22_hello_world_with_agent_server.py
+++ b/examples/22_hello_world_with_agent_server.py
@@ -122,7 +122,7 @@ api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 llm = LLM(
-    service_id="test-llm",
+    service_id="main-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/23_hello_world_with_sandboxed_server.py
+++ b/examples/23_hello_world_with_sandboxed_server.py
@@ -43,6 +43,7 @@ def main() -> None:
     assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
     llm = LLM(
+        service_id="test-llm",
         model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
         base_url="https://llm-proxy.eval.all-hands.dev",
         api_key=SecretStr(api_key),

--- a/examples/23_hello_world_with_sandboxed_server.py
+++ b/examples/23_hello_world_with_sandboxed_server.py
@@ -43,7 +43,7 @@ def main() -> None:
     assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
     llm = LLM(
-        service_id="test-llm",
+        service_id="main-llm",
         model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
         base_url="https://llm-proxy.eval.all-hands.dev",
         api_key=SecretStr(api_key),

--- a/openhands/agent_server/conversation_router.py
+++ b/openhands/agent_server/conversation_router.py
@@ -34,6 +34,7 @@ START_CONVERSATION_EXAMPLES = [
     StartConversationRequest(
         agent=Agent(
             llm=LLM(
+                service_id="test-llm",
                 model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
                 base_url="https://llm-proxy.app.all-hands.dev",
                 api_key=SecretStr("secret"),

--- a/openhands/sdk/conversation/conversation_stats.py
+++ b/openhands/sdk/conversation/conversation_stats.py
@@ -32,7 +32,7 @@ class ConversationStats(BaseModel):
     def register_llm(self, event: RegistryEvent):
         # Listen for llm creations and track their metrics
         llm = event.llm
-        service_id = event.service_id
+        service_id = llm.service_id
 
         # Service costs exists but has not been restored yet
         if (

--- a/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands/sdk/conversation/impl/local_conversation.py
@@ -105,7 +105,7 @@ class LocalConversation(BaseConversation):
         self.llm_registry = LLMRegistry()
         self.llm_registry.subscribe(self._state.stats.register_llm)
         for llm in list(self.agent.get_all_llms()):
-            self.llm_registry.add(llm.service_id, llm)
+            self.llm_registry.add(llm)
 
     @property
     def id(self) -> ConversationID:

--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -187,7 +187,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         ),
     )
     service_id: str = Field(
-        default="default",
         description="Unique identifier for LLM. Typically used by LLM registry.",
     )
 

--- a/openhands/sdk/llm/llm_registry.py
+++ b/openhands/sdk/llm/llm_registry.py
@@ -12,7 +12,6 @@ logger = get_logger(__name__)
 
 class RegistryEvent(BaseModel):
     llm: LLM
-    service_id: str
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -60,26 +59,25 @@ class LLMRegistry:
             except Exception as e:
                 logger.warning(f"Failed to emit event: {e}")
 
-    def add(self, service_id: str, llm: LLM) -> None:
+    def add(self, llm: LLM) -> None:
         """Add an LLM instance to the registry.
 
         Args:
-            service_id: Unique identifier for the LLM service.
             llm: The LLM instance to register.
 
         Raises:
-            ValueError: If service_id already exists in the registry.
+            ValueError: If llm.service_id already exists in the registry.
         """
+        service_id = llm.service_id
         if service_id in self.service_to_llm:
             raise ValueError(
                 f"Service ID '{service_id}' already exists in registry. "
-                "Use a different service_id or call get() to retrieve the existing LLM."
+                "Use a different service_id on the LLM or call get() to retrieve the "
+                "existing LLM."
             )
 
-        # Set the service_id on the LLM instance
-        llm.service_id = service_id
         self.service_to_llm[service_id] = llm
-        self.notify(RegistryEvent(llm=llm, service_id=service_id))
+        self.notify(RegistryEvent(llm=llm))
         logger.info(
             f"[LLM registry {self.registry_id}]: Added LLM for service {service_id}"
         )

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -29,7 +29,7 @@ def sample_stored_conversation():
     """Create a sample StoredConversation for testing."""
     return StoredConversation(
         id=uuid4(),
-        agent=Agent(llm=LLM(model="gpt-4"), tools=[]),
+        agent=Agent(llm=LLM(model="gpt-4", service_id="test-llm"), tools=[]),
         confirmation_policy=NeverConfirm(),
         initial_message=None,
         metrics=None,
@@ -110,7 +110,7 @@ class TestConversationServiceSearchConversations:
         ):
             stored_conv = StoredConversation(
                 id=uuid4(),
-                agent=Agent(llm=LLM(model="gpt-4"), tools=[]),
+                agent=Agent(llm=LLM(model="gpt-4", service_id="test-llm"), tools=[]),
                 confirmation_policy=NeverConfirm(),
                 initial_message=None,
                 metrics=None,
@@ -160,7 +160,7 @@ class TestConversationServiceSearchConversations:
         for i in range(3):
             stored_conv = StoredConversation(
                 id=uuid4(),
-                agent=Agent(llm=LLM(model="gpt-4"), tools=[]),
+                agent=Agent(llm=LLM(model="gpt-4", service_id="test-llm"), tools=[]),
                 confirmation_policy=NeverConfirm(),
                 initial_message=None,
                 metrics=None,
@@ -235,7 +235,7 @@ class TestConversationServiceSearchConversations:
         for i in range(5):
             stored_conv = StoredConversation(
                 id=uuid4(),
-                agent=Agent(llm=LLM(model="gpt-4"), tools=[]),
+                agent=Agent(llm=LLM(model="gpt-4", service_id="test-llm"), tools=[]),
                 confirmation_policy=NeverConfirm(),
                 initial_message=None,
                 metrics=None,
@@ -303,7 +303,7 @@ class TestConversationServiceSearchConversations:
         for status, created_at in conversations_data:
             stored_conv = StoredConversation(
                 id=uuid4(),
-                agent=Agent(llm=LLM(model="gpt-4"), tools=[]),
+                agent=Agent(llm=LLM(model="gpt-4", service_id="test-llm"), tools=[]),
                 confirmation_policy=NeverConfirm(),
                 initial_message=None,
                 metrics=None,
@@ -416,7 +416,7 @@ class TestConversationServiceCountConversations:
         for i, status in enumerate(statuses):
             stored_conv = StoredConversation(
                 id=uuid4(),
-                agent=Agent(llm=LLM(model="gpt-4"), tools=[]),
+                agent=Agent(llm=LLM(model="gpt-4", service_id="test-llm"), tools=[]),
                 confirmation_policy=NeverConfirm(),
                 initial_message=None,
                 metrics=None,

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -22,7 +22,7 @@ def sample_stored_conversation():
     """Create a sample StoredConversation for testing."""
     return StoredConversation(
         id=uuid4(),
-        agent=Agent(llm=LLM(model="gpt-4"), tools=[]),
+        agent=Agent(llm=LLM(model="gpt-4", service_id="test-llm"), tools=[]),
         confirmation_policy=NeverConfirm(),
         initial_message=None,
         metrics=None,

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -35,6 +35,7 @@ def mock_event_service():
                 id=uuid4(),
                 agent=Agent(
                     llm=LLM(
+                        service_id="test-llm",
                         model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
                         base_url="https://llm-proxy.staging.all-hands.dev",
                         api_key=SecretStr("fake-secret"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ def mock_llm():
     return LLM(
         model="gpt-4o",
         api_key=SecretStr("test-key"),
+        service_id="test-llm",
         num_retries=2,
         retry_min_wait=1,
         retry_max_wait=2,

--- a/tests/cross/test_agent_secrets_integration.py
+++ b/tests/cross/test_agent_secrets_integration.py
@@ -22,7 +22,9 @@ from openhands.tools.execute_bash.impl import BashExecutor
 
 @pytest.fixture
 def llm() -> LLM:
-    return LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+    return LLM(
+        model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+    )
 
 
 @pytest.fixture

--- a/tests/cross/test_hello_world.py
+++ b/tests/cross/test_hello_world.py
@@ -158,6 +158,7 @@ class TestHelloWorld:
 
         # Configure LLM (no real API key needed)
         llm = LLM(
+            service_id="test-llm",
             model="claude-sonnet-4",
             api_key=SecretStr("mock-api-key"),
         )
@@ -273,6 +274,7 @@ class TestHelloWorld:
 
         # Configure LLM with logging enabled
         llm = LLM(
+            service_id="test-llm",
             model="claude-sonnet-4",
             api_key=SecretStr("mock-api-key"),
         )
@@ -421,7 +423,7 @@ class TestHelloWorld:
             return mock_response
 
         # Create agent with mocked LLM
-        llm = LLM(model="claude-sonnet-4")
+        llm = LLM(model="claude-sonnet-4", service_id="test-llm")
         agent = Agent(llm=llm, tools=[])
 
         # Mock the completion method
@@ -515,7 +517,7 @@ class TestHelloWorld:
             return mock_response
 
         # Create agent with mocked LLM
-        agent = Agent(llm=LLM(model="claude-sonnet-4"), tools=[])
+        agent = Agent(llm=LLM(model="claude-sonnet-4", service_id="test-llm"), tools=[])
 
         # Mock the completion method
         with patch(

--- a/tests/cross/test_local_conversation_tools_integration.py
+++ b/tests/cross/test_local_conversation_tools_integration.py
@@ -29,7 +29,9 @@ def test_conversation_with_different_agent_tools_raises_error():
             ToolSpec(name="BashTool", params={"working_dir": temp_dir}),
             ToolSpec(name="FileEditorTool"),
         ]
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         original_agent = Agent(llm=llm, tools=original_tools)
         conversation = LocalConversation(
             agent=original_agent, persist_filestore=file_store, visualize=False
@@ -50,7 +52,9 @@ def test_conversation_with_different_agent_tools_raises_error():
         different_tools = [
             ToolSpec(name="BashTool", params={"working_dir": temp_dir})
         ]  # Missing FileEditorTool
-        llm2 = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm2 = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         different_agent = Agent(llm=llm2, tools=different_tools)
 
         # This should raise ValueError due to tool differences
@@ -75,7 +79,9 @@ def test_conversation_with_same_agent_succeeds():
             ToolSpec(name="BashTool", params={"working_dir": temp_dir}),
             ToolSpec(name="FileEditorTool"),
         ]
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         original_agent = Agent(llm=llm, tools=tools)
         conversation = LocalConversation(
             agent=original_agent, persist_filestore=file_store, visualize=False
@@ -97,7 +103,9 @@ def test_conversation_with_same_agent_succeeds():
             ToolSpec(name="BashTool", params={"working_dir": temp_dir}),
             ToolSpec(name="FileEditorTool"),
         ]
-        llm2 = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm2 = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         same_agent = Agent(llm=llm2, tools=same_tools)
 
         # This should succeed
@@ -129,7 +137,9 @@ def test_conversation_persistence_lifecycle(mock_completion):
             ToolSpec(name="BashTool", params={"working_dir": temp_dir}),
             ToolSpec(name="FileEditorTool"),
         ]
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         agent = Agent(llm=llm, tools=tools)
 
         # Create conversation and send messages
@@ -192,7 +202,9 @@ def test_agent_resolve_diff_from_deserialized():
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create original agent
         tools = [ToolSpec(name="BashTool", params={"working_dir": temp_dir})]
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         original_agent = Agent(llm=llm, tools=tools)
 
         # Serialize and deserialize to simulate persistence
@@ -200,7 +212,9 @@ def test_agent_resolve_diff_from_deserialized():
         deserialized_agent = AgentBase.model_validate_json(serialized)
 
         # Create runtime agent with same configuration
-        llm2 = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm2 = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         runtime_agent = Agent(llm=llm2, tools=tools)
 
         # Should resolve successfully

--- a/tests/cross/test_stuck_detector.py
+++ b/tests/cross/test_stuck_detector.py
@@ -21,7 +21,7 @@ from openhands.tools.execute_bash.definition import (
 def test_history_too_short():
     """Test that stuck detector returns False when there are too few events."""
     # Create a minimal agent for testing
-    llm = LLM(model="gpt-4o-mini")
+    llm = LLM(model="gpt-4o-mini", service_id="test-llm")
     agent = Agent(llm=llm)
     state = ConversationState.create(id=uuid.uuid4(), agent=agent)
     stuck_detector = StuckDetector(state)
@@ -66,7 +66,7 @@ def test_history_too_short():
 
 def test_repeating_action_observation_not_stuck_less_than_4_repeats():
     """Test detection of repeating action-observation cycles."""
-    llm = LLM(model="gpt-4o-mini")
+    llm = LLM(model="gpt-4o-mini", service_id="test-llm")
     agent = Agent(llm=llm)
     state = ConversationState.create(id=uuid.uuid4(), agent=agent)
     stuck_detector = StuckDetector(state)
@@ -112,7 +112,7 @@ def test_repeating_action_observation_not_stuck_less_than_4_repeats():
 
 def test_repeating_action_observation_stuck():
     """Test detection of repeating action-observation cycles."""
-    llm = LLM(model="gpt-4o-mini")
+    llm = LLM(model="gpt-4o-mini", service_id="test-llm")
     agent = Agent(llm=llm)
     state = ConversationState.create(id=uuid.uuid4(), agent=agent)
     stuck_detector = StuckDetector(state)
@@ -158,7 +158,7 @@ def test_repeating_action_observation_stuck():
 
 def test_repeating_action_error_stuck():
     """Test detection of repeating action-error cycles."""
-    llm = LLM(model="gpt-4o-mini")
+    llm = LLM(model="gpt-4o-mini", service_id="test-llm")
     agent = Agent(llm=llm)
     state = ConversationState.create(id=uuid.uuid4(), agent=agent)
     stuck_detector = StuckDetector(state)
@@ -217,7 +217,7 @@ def test_repeating_action_error_stuck():
 
 def test_agent_monologue_stuck():
     """Test detection of agent monologue (repeated messages without user input)."""
-    llm = LLM(model="gpt-4o-mini")
+    llm = LLM(model="gpt-4o-mini", service_id="test-llm")
     agent = Agent(llm=llm)
     state = ConversationState.create(id=uuid.uuid4(), agent=agent)
     stuck_detector = StuckDetector(state)
@@ -245,7 +245,7 @@ def test_agent_monologue_stuck():
 
 def test_not_stuck_with_different_actions():
     """Test that different actions don't trigger stuck detection."""
-    llm = LLM(model="gpt-4o-mini")
+    llm = LLM(model="gpt-4o-mini", service_id="test-llm")
     agent = Agent(llm=llm)
     state = ConversationState.create(id=uuid.uuid4(), agent=agent)
     stuck_detector = StuckDetector(state)
@@ -297,7 +297,7 @@ def test_not_stuck_with_different_actions():
 
 def test_reset_after_user_message():
     """Test that stuck detection resets after a new user message."""
-    llm = LLM(model="gpt-4o-mini")
+    llm = LLM(model="gpt-4o-mini", service_id="test-llm")
     agent = Agent(llm=llm)
     state = ConversationState.create(id=uuid.uuid4(), agent=agent)
     stuck_detector = StuckDetector(state)

--- a/tests/fixtures/llm_data/data_generator.py
+++ b/tests/fixtures/llm_data/data_generator.py
@@ -54,7 +54,7 @@ def create_llm(
     }
     if log_completions_folder:
         llm_kwargs["log_completions_folder"] = log_completions_folder
-    return LLM(**llm_kwargs)
+    return LLM(**llm_kwargs, service_id="test-llm")
 
 
 def create_tools(working_dir: str | None = None) -> list[ToolSpec]:

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -70,7 +70,7 @@ class BaseIntegrationTest(ABC):
             "api_key": SecretStr(api_key),
         }
 
-        self.llm = LLM(**llm_kwargs)
+        self.llm = LLM(**llm_kwargs, service_id="test-llm")
         self.agent = Agent(llm=self.llm, tools=self.tools)
         self.collected_events: list[EventBase] = []
         self.llm_messages: list[dict[str, Any]] = []

--- a/tests/sdk/agent/test_agent_immutability.py
+++ b/tests/sdk/agent/test_agent_immutability.py
@@ -13,7 +13,9 @@ class TestAgentImmutability:
 
     def setup_method(self):
         """Set up test environment."""
-        self.llm = LLM(model="gpt-4", api_key=SecretStr("test-key"))
+        self.llm = LLM(
+            model="gpt-4", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
 
     def test_agent_is_frozen(self):
         """Test that Agent instances are frozen (immutable)."""

--- a/tests/sdk/agent/test_agent_llms_are_discoverable.py
+++ b/tests/sdk/agent/test_agent_llms_are_discoverable.py
@@ -76,7 +76,8 @@ def test_automatic_llm_discovery_with_multimodal_router():
 
     # Create MultimodalRouter with the LLMs
     multimodal_router = MultimodalRouter(
-        llms_for_routing={"primary": primary_llm, "secondary": secondary_llm}
+        service_id="multimodal-router",
+        llms_for_routing={"primary": primary_llm, "secondary": secondary_llm},
     )
 
     # Create agent with the router

--- a/tests/sdk/agent/test_agent_serialization.py
+++ b/tests/sdk/agent/test_agent_serialization.py
@@ -37,7 +37,7 @@ def create_mock_mcp_tool(name: str) -> MCPTool:
 def test_agent_supports_polymorphic_json_serialization() -> None:
     """Test that Agent supports polymorphic JSON serialization/deserialization."""
     # Create a simple LLM instance and agent with empty tools
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
 
     # Serialize to JSON (excluding non-serializable fields)
@@ -60,7 +60,7 @@ def test_mcp_tool_serialization():
 
 def test_agent_serialization_should_include_mcp_tool() -> None:
     # Create a simple LLM instance and agent with empty tools
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
     mcp_config = {
         "mcpServers": {
             "dummy": {"command": "echo", "args": ["dummy-mcp"]},
@@ -88,7 +88,7 @@ def test_agent_supports_polymorphic_field_json_serialization() -> None:
         agent: Agent  # Use direct Agent type instead of DiscriminatedUnionType
 
     # Create container with agent
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
     container = Container(agent=agent)
 
@@ -110,8 +110,8 @@ def test_agent_supports_nested_polymorphic_json_serialization() -> None:
         agents: list[Agent]  # Use direct Agent type
 
     # Create container with multiple agents
-    llm1 = LLM(model="model-1")
-    llm2 = LLM(model="model-2")
+    llm1 = LLM(model="model-1", service_id="test-llm")
+    llm2 = LLM(model="model-2", service_id="test-llm")
     agent1 = Agent(llm=llm1, tools=[])
     agent2 = Agent(llm=llm2, tools=[])
     container = NestedContainer(agents=[agent1, agent2])
@@ -133,7 +133,7 @@ def test_agent_supports_nested_polymorphic_json_serialization() -> None:
 def test_agent_model_validate_json_dict() -> None:
     """Test that Agent.model_validate works with dict from JSON."""
     # Create agent
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
 
     # Serialize to JSON, then parse to dict
@@ -161,7 +161,7 @@ def test_agent_fallback_behavior_json() -> None:
 def test_agent_preserves_pydantic_parameters_json() -> None:
     """Test that Agent preserves Pydantic parameters through JSON serialization."""
     # Create agent with extra data
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
 
     # Serialize to JSON
@@ -177,7 +177,7 @@ def test_agent_preserves_pydantic_parameters_json() -> None:
 def test_agent_type_annotation_works_json() -> None:
     """Test that AgentType annotation works correctly with JSON."""
     # Create agent
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
 
     # Use AgentType annotation
@@ -201,7 +201,7 @@ def test_agent_type_annotation_works_json() -> None:
 def test_agent_type_annotation_on_basemodel_works_json() -> None:
     """Test that AgentType annotation works correctly with JSON."""
     # Create agent
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
 
     # Use AgentType annotation

--- a/tests/sdk/agent/test_agent_toolspec_init.py
+++ b/tests/sdk/agent/test_agent_toolspec_init.py
@@ -38,7 +38,7 @@ def test_agent_initializes_tools_from_toolspec_locally(monkeypatch):
     # Register a simple local tool via registry
     register_tool("upper", _make_tool)
 
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
     agent = Agent(llm=llm, tools=[ToolSpec(name="upper")])
 
     # Build a conversation; this should call agent._initialize() internally

--- a/tests/sdk/agent/test_message_while_finishing.py
+++ b/tests/sdk/agent/test_message_while_finishing.py
@@ -139,7 +139,7 @@ class TestMessageWhileFinishing:
     def setup_method(self):
         """Set up test fixtures."""
         # Use gpt-4o which supports native function calling and multiple tool calls
-        self.llm = LLM(model="gpt-4o", native_tool_calling=True)
+        self.llm = LLM(model="gpt-4o", native_tool_calling=True, service_id="test-llm")
         self.llm_completion_calls = []
         self.agent = Agent(llm=self.llm, tools=[ToolSpec(name="SleepTool")])
         self.step_count = 0

--- a/tests/sdk/agent/test_security_policy_integration.py
+++ b/tests/sdk/agent/test_security_policy_integration.py
@@ -12,7 +12,10 @@ def test_security_policy_in_system_message():
     # Create a minimal agent configuration
     agent = Agent(
         llm=LLM(
-            model="test-model", api_key=SecretStr("test-key"), base_url="http://test"
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
         )
     )
 
@@ -53,7 +56,10 @@ def test_security_policy_template_rendering():
     # Get the prompts directory
     agent = Agent(
         llm=LLM(
-            model="test-model", api_key=SecretStr("test-key"), base_url="http://test"
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
         )
     )
     prompt_dir = agent.prompt_dir
@@ -77,7 +83,10 @@ def test_llm_security_analyzer_template_kwargs():
     # Create agent with LLMSecurityAnalyzer
     agent = Agent(
         llm=LLM(
-            model="test-model", api_key=SecretStr("test-key"), base_url="http://test"
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
         ),
         security_analyzer=LLMSecurityAnalyzer(),
     )
@@ -101,7 +110,10 @@ def test_llm_security_analyzer_sandbox_mode():
     # Create agent with LLMSecurityAnalyzer and cli_mode=False
     agent = Agent(
         llm=LLM(
-            model="test-model", api_key=SecretStr("test-key"), base_url="http://test"
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
         ),
         security_analyzer=LLMSecurityAnalyzer(),
         system_prompt_kwargs={"cli_mode": False},
@@ -126,7 +138,10 @@ def test_no_security_analyzer_excludes_risk_assessment():
     # Create agent without security analyzer
     agent = Agent(
         llm=LLM(
-            model="test-model", api_key=SecretStr("test-key"), base_url="http://test"
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
         )
     )
 
@@ -155,7 +170,10 @@ def test_non_llm_security_analyzer_excludes_risk_assessment():
     # Create agent with non-LLM security analyzer
     agent = Agent(
         llm=LLM(
-            model="test-model", api_key=SecretStr("test-key"), base_url="http://test"
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
         ),
         security_analyzer=MockSecurityAnalyzer(),
     )

--- a/tests/sdk/config/test_llm_config.py
+++ b/tests/sdk/config/test_llm_config.py
@@ -9,7 +9,7 @@ from openhands.sdk.llm import LLM
 
 def test_llm_config_defaults():
     """Test LLM with default values."""
-    config = LLM(model="gpt-4")
+    config = LLM(model="gpt-4", service_id="test-llm")
     assert config.model == "gpt-4"
     assert config.api_key is None
     assert config.base_url is None
@@ -45,6 +45,7 @@ def test_llm_config_defaults():
 def test_llm_config_custom_values():
     """Test LLM with custom values."""
     config = LLM(
+        service_id="test-llm",
         model="gpt-4",
         api_key=SecretStr("test-key"),
         base_url="https://api.example.com",
@@ -120,7 +121,7 @@ def test_llm_config_custom_values():
 
 def test_llm_config_secret_str():
     """Test that api_key is properly handled as SecretStr."""
-    config = LLM(model="gpt-4", api_key=SecretStr("secret-key"))
+    config = LLM(model="gpt-4", api_key=SecretStr("secret-key"), service_id="test-llm")
     assert (
         config.api_key is not None and config.api_key.get_secret_value() == "secret-key"
     )
@@ -131,6 +132,7 @@ def test_llm_config_secret_str():
 def test_llm_config_aws_credentials():
     """Test AWS credentials handling."""
     config = LLM(
+        service_id="test-llm",
         model="gpt-4",
         aws_access_key_id=SecretStr("test-access-key"),
         aws_secret_access_key=SecretStr("test-secret-key"),
@@ -149,7 +151,7 @@ def test_llm_config_aws_credentials():
 
 def test_llm_config_openrouter_defaults():
     """Test OpenRouter default values."""
-    config = LLM(model="gpt-4")
+    config = LLM(model="gpt-4", service_id="test-llm")
     assert config.openrouter_site_url == "https://docs.all-hands.dev/"
     assert config.openrouter_app_name == "OpenHands"
 
@@ -161,6 +163,7 @@ def test_llm_config_post_init_openrouter_env_vars():
             model="gpt-4",
             openrouter_site_url="https://custom.site.com",
             openrouter_app_name="CustomApp",
+            service_id="test-llm",
         )
         assert os.environ.get("OR_SITE_URL") == "https://custom.site.com"
         assert os.environ.get("OR_APP_NAME") == "CustomApp"
@@ -168,25 +171,27 @@ def test_llm_config_post_init_openrouter_env_vars():
 
 def test_llm_config_post_init_reasoning_effort_default():
     """Test that reasoning_effort is set to 'high' by default for non-Gemini models."""
-    config = LLM(model="gpt-4")
+    config = LLM(model="gpt-4", service_id="test-llm")
     assert config.reasoning_effort == "high"
 
     # Test that Gemini models don't get default reasoning_effort
-    config = LLM(model="gemini-2.5-pro-experimental")
+    config = LLM(model="gemini-2.5-pro-experimental", service_id="test-llm")
     assert config.reasoning_effort is None
 
 
 def test_llm_config_post_init_azure_api_version():
     """Test that Azure models get default API version."""
-    config = LLM(model="azure/gpt-4")
+    config = LLM(model="azure/gpt-4", service_id="test-llm")
     assert config.api_version == "2024-12-01-preview"
 
     # Test that non-Azure models don't get default API version
-    config = LLM(model="gpt-4")
+    config = LLM(model="gpt-4", service_id="test-llm")
     assert config.api_version is None
 
     # Test that explicit API version is preserved
-    config = LLM(model="azure/gpt-4", api_version="custom-version")
+    config = LLM(
+        model="azure/gpt-4", api_version="custom-version", service_id="test-llm"
+    )
     assert config.api_version == "custom-version"
 
 
@@ -194,6 +199,7 @@ def test_llm_config_post_init_aws_env_vars():
     """Test that AWS credentials are set as environment variables."""
     with patch.dict(os.environ, {}, clear=True):
         LLM(
+            service_id="test-llm",
             model="gpt-4",
             aws_access_key_id=SecretStr("test-access-key"),
             aws_secret_access_key=SecretStr("test-secret-key"),
@@ -206,7 +212,7 @@ def test_llm_config_post_init_aws_env_vars():
 
 def test_llm_config_log_completions_folder_default():
     """Test that log_completions_folder has a default value."""
-    config = LLM(model="gpt-4")
+    config = LLM(model="gpt-4", service_id="test-llm")
     assert config.log_completions_folder is not None
     assert "completions" in config.log_completions_folder
 
@@ -214,7 +220,7 @@ def test_llm_config_log_completions_folder_default():
 def test_llm_config_extra_fields_forbidden():
     """Test that extra fields are forbidden."""
     with pytest.raises(ValidationError) as exc_info:
-        LLM(model="gpt-4", invalid_field="should_not_work")  # type: ignore
+        LLM(model="gpt-4", invalid_field="should_not_work", service_id="test-llm")  # type: ignore
     assert "Extra inputs are not permitted" in str(exc_info.value)
 
 
@@ -232,6 +238,7 @@ def test_llm_config_validation():
             max_message_chars=-1,  # Should fail: ge=1
             temperature=-1,  # Should fail: ge=0
             top_p=-1,  # Should fail: ge=0
+            service_id="test-llm",
         )
 
     # Verify that the validation error contains expected field names
@@ -260,6 +267,7 @@ def test_llm_config_validation():
         max_message_chars=1,  # Valid: ge=1
         temperature=0.0,  # Valid: ge=0
         top_p=0.0,  # Valid: ge=0
+        service_id="test-llm",
     )
     assert config.num_retries == 0
     assert config.retry_multiplier == 0.0
@@ -283,7 +291,7 @@ def test_llm_config_model_variants():
     ]
 
     for model in models:
-        config = LLM(model=model)
+        config = LLM(model=model, service_id="test-llm")
         assert config.model == model
 
 
@@ -298,6 +306,7 @@ def test_llm_config_boolean_fields():
         caching_prompt=True,
         log_completions=False,
         native_tool_calling=True,
+        service_id="test-llm",
     )
 
     assert config.drop_params is True
@@ -334,6 +343,7 @@ def test_llm_config_optional_fields():
         reasoning_effort=None,
         seed=None,
         safety_settings=None,
+        service_id="test-llm",
     )
 
     assert config.api_key is None

--- a/tests/sdk/conversation/local/test_confirmation_mode.py
+++ b/tests/sdk/conversation/local/test_confirmation_mode.py
@@ -55,7 +55,9 @@ class TestConfirmationMode:
         """Set up test fixtures."""
 
         # Create a real LLM instance for Agent validation
-        self.llm = LLM(model="gpt-4", api_key=SecretStr("test-key"))
+        self.llm = LLM(
+            model="gpt-4", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
 
         # Create a MagicMock to override the completion method
         self.mock_llm = MagicMock()

--- a/tests/sdk/conversation/local/test_conversation_core.py
+++ b/tests/sdk/conversation/local/test_conversation_core.py
@@ -18,7 +18,7 @@ from openhands.sdk.llm import LLM, Message, TextContent
 
 def create_test_agent() -> Agent:
     """Create a test agent."""
-    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm")
     return Agent(llm=llm, tools=[])
 
 

--- a/tests/sdk/conversation/local/test_conversation_default_callback.py
+++ b/tests/sdk/conversation/local/test_conversation_default_callback.py
@@ -10,7 +10,9 @@ from openhands.sdk.llm import LLM, Message, TextContent
 
 class TestConversationDefaultCallbackDummyAgent(AgentBase):
     def __init__(self):
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         super().__init__(llm=llm, tools=[])
 
     def init_state(

--- a/tests/sdk/conversation/local/test_conversation_id.py
+++ b/tests/sdk/conversation/local/test_conversation_id.py
@@ -13,7 +13,9 @@ from openhands.sdk.security.confirmation_policy import AlwaysConfirm, NeverConfi
 
 class TestConversationIdDummyAgent(AgentBase):
     def __init__(self):
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         super().__init__(llm=llm, tools=[])
 
     def init_state(

--- a/tests/sdk/conversation/local/test_conversation_pause_functionality.py
+++ b/tests/sdk/conversation/local/test_conversation_pause_functionality.py
@@ -79,7 +79,9 @@ class TestPauseFunctionality:
     def setup_method(self):
         """Set up test fixtures."""
 
-        self.llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        self.llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
 
         class TestExecutor(
             ToolExecutor[

--- a/tests/sdk/conversation/local/test_conversation_send_message.py
+++ b/tests/sdk/conversation/local/test_conversation_send_message.py
@@ -10,7 +10,9 @@ from openhands.sdk.llm import LLM, Message, TextContent
 
 class TestSendMessageDummyAgent(AgentBase):
     def __init__(self):
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         super().__init__(llm=llm, tools=[])
 
     def init_state(

--- a/tests/sdk/conversation/local/test_conversation_visualize_param.py
+++ b/tests/sdk/conversation/local/test_conversation_visualize_param.py
@@ -23,7 +23,7 @@ def create_test_event(content: str = "Test event content") -> MessageEvent:
 @pytest.fixture
 def mock_agent():
     """Create a real agent for testing."""
-    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
     return agent
 

--- a/tests/sdk/conversation/local/test_state_serialization.py
+++ b/tests/sdk/conversation/local/test_state_serialization.py
@@ -20,7 +20,7 @@ from openhands.sdk.security.confirmation_policy import AlwaysConfirm
 
 def test_conversation_state_basic_serialization():
     """Test basic ConversationState serialization and deserialization."""
-    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
     state = ConversationState.create(
         agent=agent, id=uuid.UUID("12345678-1234-5678-9abc-123456789001")
@@ -69,7 +69,9 @@ def test_conversation_state_persistence_save_load():
     """Test ConversationState persistence with FileStore."""
     with tempfile.TemporaryDirectory() as temp_dir:
         file_store = LocalFileStore(temp_dir)
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         agent = Agent(llm=llm, tools=[])
         state = ConversationState.create(
             agent=agent,
@@ -87,7 +89,7 @@ def test_conversation_state_persistence_save_load():
         )
         state.events.append(event1)
         state.events.append(event2)
-        state.stats.register_llm(RegistryEvent(llm=llm, service_id=llm.service_id))
+        state.stats.register_llm(RegistryEvent(llm=llm))
 
         # State auto-saves when events are added
         # Verify files were created
@@ -124,7 +126,9 @@ def test_conversation_state_incremental_save():
     """Test that ConversationState saves events incrementally."""
     with tempfile.TemporaryDirectory() as temp_dir:
         file_store = LocalFileStore(temp_dir)
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         agent = Agent(llm=llm, tools=[])
         state = ConversationState.create(
             agent=agent,
@@ -137,7 +141,7 @@ def test_conversation_state_incremental_save():
             source="agent", system_prompt=TextContent(text="system"), tools=[]
         )
         state.events.append(event1)
-        state.stats.register_llm(RegistryEvent(llm=llm, service_id=llm.service_id))
+        state.stats.register_llm(RegistryEvent(llm=llm))
 
         # Verify event files exist (may have additional events from Agent.init_state)
         event_files = list(Path(temp_dir, "events").glob("*.json"))
@@ -170,7 +174,9 @@ def test_conversation_state_event_file_scanning():
     """Test event file scanning and sorting logic through EventLog."""
     with tempfile.TemporaryDirectory() as temp_dir:
         file_store = LocalFileStore(temp_dir)
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         agent = Agent(llm=llm, tools=[])
 
         # Create event files with valid format (new pattern)
@@ -222,7 +228,9 @@ def test_conversation_state_corrupted_event_handling():
     """Test handling of corrupted event files during replay."""
     with tempfile.TemporaryDirectory() as temp_dir:
         file_store = LocalFileStore(temp_dir)
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         agent = Agent(llm=llm, tools=[])
 
         # Create event files with some corrupted
@@ -265,7 +273,9 @@ def test_conversation_state_empty_filestore():
     """Test ConversationState behavior with empty filestore."""
     with tempfile.TemporaryDirectory() as temp_dir:
         file_store = LocalFileStore(temp_dir)
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         agent = Agent(llm=llm, tools=[])
 
         # Create conversation with empty filestore
@@ -283,7 +293,9 @@ def test_conversation_state_missing_base_state():
     """Test error handling when base_state.json is missing but events exist."""
     with tempfile.TemporaryDirectory() as temp_dir:
         file_store = LocalFileStore(temp_dir)
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         agent = Agent(llm=llm, tools=[])
 
         # Create events directory with files but no base_state.json
@@ -313,7 +325,9 @@ def test_conversation_state_exclude_from_base_state():
     """Test that events are excluded from base state serialization."""
     with tempfile.TemporaryDirectory() as temp_dir:
         file_store = LocalFileStore(temp_dir)
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         agent = Agent(llm=llm, tools=[])
         state = ConversationState.create(
             agent=agent,
@@ -339,7 +353,7 @@ def test_conversation_state_exclude_from_base_state():
 
 def test_conversation_state_thread_safety():
     """Test ConversationState thread safety with lock/unlock."""
-    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
     state = ConversationState.create(
         agent=agent, id=uuid.UUID("12345678-1234-5678-9abc-123456789005")
@@ -366,7 +380,11 @@ def test_agent_resolve_diff_different_class_raises_error():
 
     class DifferentAgent(AgentBase):
         def __init__(self):
-            llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+            llm = LLM(
+                model="gpt-4o-mini",
+                api_key=SecretStr("test-key"),
+                service_id="test-llm",
+            )
             super().__init__(llm=llm, tools=[])
 
         def init_state(self, state, on_event):
@@ -375,7 +393,7 @@ def test_agent_resolve_diff_different_class_raises_error():
         def step(self, state, on_event):
             pass
 
-    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm")
     original_agent = Agent(llm=llm, tools=[])
     different_agent = DifferentAgent()
 
@@ -387,7 +405,9 @@ def test_conversation_state_flags_persistence():
     """Test that conversation state flags are properly persisted."""
     with tempfile.TemporaryDirectory() as temp_dir:
         file_store = LocalFileStore(temp_dir)
-        llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm"
+        )
         agent = Agent(llm=llm, tools=[])
         state = ConversationState.create(
             agent=agent,
@@ -395,7 +415,7 @@ def test_conversation_state_flags_persistence():
             file_store=file_store,
         )
 
-        state.stats.register_llm(RegistryEvent(llm=llm, service_id=llm.service_id))
+        state.stats.register_llm(RegistryEvent(llm=llm))
 
         # Set various flags
         state.agent_status = AgentExecutionStatus.FINISHED
@@ -427,7 +447,11 @@ def test_conversation_with_agent_different_llm_config():
         file_store = LocalFileStore(temp_dir)
 
         # Create conversation with original LLM config
-        original_llm = LLM(model="gpt-4o-mini", api_key=SecretStr("original-key"))
+        original_llm = LLM(
+            model="gpt-4o-mini",
+            api_key=SecretStr("original-key"),
+            service_id="test-llm",
+        )
         original_agent = Agent(llm=original_llm, tools=[])
         conversation = Conversation(
             agent=original_agent, persist_filestore=file_store, visualize=False
@@ -447,7 +471,9 @@ def test_conversation_with_agent_different_llm_config():
         del conversation
 
         # Try with different LLM config (different API key should be resolved)
-        new_llm = LLM(model="gpt-4o-mini", api_key=SecretStr("new-key"))
+        new_llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("new-key"), service_id="test-llm"
+        )
         new_agent = Agent(llm=new_llm, tools=[])
 
         # This should succeed because API key differences are resolved

--- a/tests/sdk/conversation/test_agent_status_enum.py
+++ b/tests/sdk/conversation/test_agent_status_enum.py
@@ -9,7 +9,7 @@ from openhands.sdk.llm import LLM
 
 def test_agent_execution_state_enum_basic():
     """Test basic AgentExecutionStatus enum functionality."""
-    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
     conversation = Conversation(agent=agent)
 
@@ -52,7 +52,7 @@ def test_enum_values():
 
 def test_enum_serialization():
     """Test that the enum serializes and deserializes correctly."""
-    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"))
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm")
     agent = Agent(llm=llm, tools=[])
     conversation = Conversation(agent=agent)
 

--- a/tests/sdk/conversation/test_conversation_stats.py
+++ b/tests/sdk/conversation/test_conversation_stats.py
@@ -121,7 +121,7 @@ def test_register_llm_with_new_service(conversation_stats):
 
         # Create a registry event
         service_id = "new-service"
-        event = RegistryEvent(llm=llm, service_id=service_id)
+        event = RegistryEvent(llm=llm)
 
         # Register the LLM
         conversation_stats.register_llm(event)
@@ -151,7 +151,7 @@ def test_register_llm_with_restored_metrics(conversation_stats):
         )
 
         # Create a registry event
-        event = RegistryEvent(llm=llm, service_id=service_id)
+        event = RegistryEvent(llm=llm)
 
         # Register the LLM
         conversation_stats.register_llm(event)
@@ -183,7 +183,7 @@ def test_llm_registry_notifications(connected_registry_and_stats):
     )
 
     # Add LLM to registry (this should trigger the notification)
-    mock_llm_registry.add(service_id, llm)
+    mock_llm_registry.add(llm)
 
     # Verify the service was registered in conversation stats
     assert service_id in conversation_stats.service_to_metrics
@@ -251,8 +251,8 @@ def test_multiple_llm_services(connected_registry_and_stats):
     )
 
     # Add LLMs to registry (this should trigger notifications)
-    mock_llm_registry.add(service1, llm1)
-    mock_llm_registry.add(service2, llm2)
+    mock_llm_registry.add(llm1)
+    mock_llm_registry.add(llm2)
 
     # Add different metrics to each LLM
     assert llm1.metrics is not None
@@ -328,7 +328,7 @@ def test_register_llm_with_multiple_restored_services(conversation_stats):
             retry_min_wait=1,
             retry_max_wait=2,
         )
-        event_1 = RegistryEvent(llm=llm_1, service_id=service_id_1)
+        event_1 = RegistryEvent(llm=llm_1)
         conversation_stats.register_llm(event_1)
 
         # Verify first service was registered with restored metrics
@@ -349,7 +349,7 @@ def test_register_llm_with_multiple_restored_services(conversation_stats):
             retry_min_wait=1,
             retry_max_wait=2,
         )
-        event_2 = RegistryEvent(llm=llm_2, service_id=service_id_2)
+        event_2 = RegistryEvent(llm=llm_2)
         conversation_stats.register_llm(event_2)
 
         # Verify second service was registered with restored metrics

--- a/tests/sdk/llm/test_api_connection_error_retry.py
+++ b/tests/sdk/llm/test_api_connection_error_retry.py
@@ -37,6 +37,7 @@ def create_mock_response(content: str = "Test response", response_id: str = "tes
 @pytest.fixture
 def default_config():
     return LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,
@@ -185,11 +186,17 @@ def test_completion_no_retry_on_non_retryable_error(
 def test_retry_configuration_validation():
     """Test that retry configuration is properly validated."""
     # Test with zero retries
-    llm_no_retry = LLM(model="gpt-4o", api_key=SecretStr("test_key"), num_retries=0)
+    llm_no_retry = LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=0,
+        service_id="test-llm",
+    )
     assert llm_no_retry.num_retries == 0
 
     # Test with custom retry settings
     llm_custom = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=5,
@@ -224,6 +231,7 @@ def test_retry_listener_callback(mock_litellm_completion, default_config):
 
     # Create an LLM instance with retry listener
     llm = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,

--- a/tests/sdk/llm/test_api_key_validation.py
+++ b/tests/sdk/llm/test_api_key_validation.py
@@ -6,7 +6,9 @@ from openhands.sdk.llm import LLM
 def test_empty_api_key_string_converted_to_none():
     """Test that empty string API keys are converted to None."""
     llm = LLM(
-        model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", api_key=SecretStr("")
+        service_id="test-llm",
+        model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+        api_key=SecretStr(""),
     )
     assert llm.api_key is None
 
@@ -14,6 +16,7 @@ def test_empty_api_key_string_converted_to_none():
 def test_whitespace_api_key_converted_to_none():
     """Test that whitespace-only API keys are converted to None."""
     llm = LLM(
+        service_id="test-llm",
         model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
         api_key=SecretStr("   "),
     )
@@ -22,14 +25,18 @@ def test_whitespace_api_key_converted_to_none():
 
 def test_valid_api_key_preserved():
     """Test that valid API keys are preserved."""
-    llm = LLM(model="gpt-4", api_key=SecretStr("valid-key"))
+    llm = LLM(model="gpt-4", api_key=SecretStr("valid-key"), service_id="test-llm")
     assert llm.api_key is not None
     assert llm.api_key.get_secret_value() == "valid-key"
 
 
 def test_none_api_key_preserved():
     """Test that None API keys remain None."""
-    llm = LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", api_key=None)
+    llm = LLM(
+        model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+        api_key=None,
+        service_id="test-llm",
+    )
     assert llm.api_key is None
 
 
@@ -38,7 +45,7 @@ def test_empty_string_direct_input():
     # This tests the case where someone might pass a string directly
     # Note: This would normally cause a validation error, but we handle it in field validator  # noqa: E501
     data = {"model": "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", "api_key": ""}
-    llm = LLM(**data)  # type: ignore[arg-type]
+    llm = LLM(**data, service_id="test-llm")  # type: ignore[arg-type]
     assert llm.api_key is None
 
 
@@ -48,7 +55,7 @@ def test_whitespace_string_direct_input():
         "model": "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
         "api_key": "   \t\n  ",
     }
-    llm = LLM(**data)  # type: ignore[arg-type]
+    llm = LLM(**data, service_id="test-llm")  # type: ignore[arg-type]
     assert llm.api_key is None
 
 
@@ -58,6 +65,7 @@ def test_bedrock_model_with_none_api_key():
         model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
         api_key=None,
         aws_region_name="us-east-1",
+        service_id="test-llm",
     )
     assert llm.api_key is None
     assert llm.aws_region_name == "us-east-1"
@@ -65,7 +73,9 @@ def test_bedrock_model_with_none_api_key():
 
 def test_non_bedrock_model_with_valid_key():
     """Test that non-Bedrock models work normally with valid API keys."""
-    llm = LLM(model="gpt-4", api_key=SecretStr("valid-openai-key"))
+    llm = LLM(
+        model="gpt-4", api_key=SecretStr("valid-openai-key"), service_id="test-llm"
+    )
     assert llm.api_key is not None
     assert llm.api_key.get_secret_value() == "valid-openai-key"
 
@@ -73,6 +83,7 @@ def test_non_bedrock_model_with_valid_key():
 def test_aws_credentials_handling():
     """Test that AWS credentials are properly handled for Bedrock models."""
     llm = LLM(
+        service_id="test-llm",
         model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
         api_key=None,
         aws_access_key_id=SecretStr("test-access-key"),

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -19,6 +19,7 @@ def default_llm():
     return LLM(
         model="gpt-4o",
         api_key=SecretStr("test_key"),
+        service_id="default-test-llm",
         num_retries=2,
         retry_min_wait=1,
         retry_max_wait=2,
@@ -37,7 +38,11 @@ def test_llm_init_with_default_config(default_llm):
 
 
 def test_base_url_for_openhands_provider():
-    llm = LLM(model="openhands/claude-sonnet-4-20250514", api_key=SecretStr("test-key"))
+    llm = LLM(
+        model="openhands/claude-sonnet-4-20250514",
+        api_key=SecretStr("test-key"),
+        service_id="test-openhands-llm",
+    )
     assert llm.base_url == "https://llm-proxy.app.all-hands.dev/"
 
 
@@ -156,6 +161,7 @@ def test_llm_completion_with_mock(mock_completion):
 
     # Create LLM after the patch is applied
     llm = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,
@@ -187,6 +193,7 @@ def test_llm_retry_on_rate_limit(mock_completion):
 
     # Create LLM after the patch is applied
     llm = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,
@@ -294,15 +301,21 @@ def test_llm_local_detection_based_on_model_name(default_llm):
 def test_llm_local_detection_based_on_base_url():
     """Test local model detection based on base_url."""
     # Test with localhost base_url
-    local_llm = LLM(model="gpt-4o", base_url="http://localhost:8000")
+    local_llm = LLM(
+        model="gpt-4o", base_url="http://localhost:8000", service_id="test-llm"
+    )
     assert local_llm.base_url == "http://localhost:8000"
 
     # Test with 127.0.0.1 base_url
-    local_llm_ip = LLM(model="gpt-4o", base_url="http://127.0.0.1:8000")
+    local_llm_ip = LLM(
+        model="gpt-4o", base_url="http://127.0.0.1:8000", service_id="test-llm"
+    )
     assert local_llm_ip.base_url == "http://127.0.0.1:8000"
 
     # Test with remote model
-    remote_llm = LLM(model="gpt-4o", base_url="https://api.openai.com/v1")
+    remote_llm = LLM(
+        model="gpt-4o", base_url="https://api.openai.com/v1", service_id="test-llm"
+    )
     assert remote_llm.base_url == "https://api.openai.com/v1"
 
 
@@ -369,11 +382,12 @@ def test_metrics_log():
 def test_llm_config_validation():
     """Test LLM configuration validation."""
     # Test with minimal valid config
-    llm = LLM(model="gpt-4o")
+    llm = LLM(model="gpt-4o", service_id="test-llm")
     assert llm.model == "gpt-4o"
 
     # Test with full config
     full_llm = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         base_url="https://api.openai.com/v1",
@@ -405,6 +419,7 @@ def test_llm_no_response_error(mock_completion):
 
     # Create LLM after the patch is applied
     llm = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -43,6 +43,7 @@ def default_config():
     return LLM(
         model="gpt-4o",
         api_key=SecretStr("test_key"),
+        service_id="test-llm",
         num_retries=2,
         retry_min_wait=1,
         retry_max_wait=2,
@@ -57,6 +58,7 @@ def test_llm_completion_basic(mock_completion):
     # Create LLM after the patch is applied
 
     llm = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,
@@ -103,6 +105,7 @@ def test_llm_completion_with_tools(mock_completion):
 
     # Create LLM after the patch is applied
     llm = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,
@@ -135,6 +138,7 @@ def test_llm_completion_error_handling(mock_completion):
 
     # Create LLM after the patch is applied
     llm = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,
@@ -244,6 +248,7 @@ def test_llm_completion_with_custom_params(mock_completion, default_config):
 
     # Create config with custom parameters
     custom_config = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         temperature=0.8,
@@ -284,6 +289,7 @@ def test_llm_completion_non_function_call_mode(mock_completion):
     # Create LLM with native_tool_calling explicitly set to False
     # This forces the LLM to use prompt-based tool calling instead of native FC
     llm = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         native_tool_calling=False,  # This is the key setting for non-function call mode
@@ -372,6 +378,7 @@ def test_llm_completion_function_call_vs_non_function_call_mode(mock_completion)
 
     # Test with native function calling enabled (default behavior for gpt-4o)
     llm_native = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         native_tool_calling=True,  # Explicitly enable native function calling
@@ -386,6 +393,7 @@ def test_llm_completion_function_call_vs_non_function_call_mode(mock_completion)
 
     # Test with native function calling disabled
     llm_non_native = LLM(
+        service_id="test-llm",
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         native_tool_calling=False,  # Explicitly disable native function calling

--- a/tests/sdk/llm/test_llm_json_storage.py
+++ b/tests/sdk/llm/test_llm_json_storage.py
@@ -13,6 +13,7 @@ def test_llm_store_and_load_json():
     """Test storing LLM to JSON and loading back with fields unchanged."""
     # Create original LLM with secrets
     original_llm = LLM(
+        service_id="test-llm",
         model="test-model",
         temperature=0.7,
         max_output_tokens=2000,

--- a/tests/sdk/llm/test_llm_registry.py
+++ b/tests/sdk/llm/test_llm_registry.py
@@ -25,14 +25,14 @@ class TestLLMRegistry(unittest.TestCase):
 
         # Create a mock LLM and add it to trigger notification
         mock_llm = Mock(spec=LLM)
-        service_id = "notify-service"
+        mock_llm.service_id = "notify-service"
 
         # Mock the RegistryEvent to avoid LLM attribute access
         with patch(
             "openhands.sdk.llm.llm_registry.RegistryEvent"
         ) as mock_registry_event:
             mock_registry_event.return_value = Mock()
-            self.registry.add(service_id, mock_llm)
+            self.registry.add(mock_llm)
 
         # Should receive notification for the newly added LLM
         self.assertEqual(len(events_received), 1)
@@ -84,15 +84,17 @@ def test_llm_registry_list_services():
 
     # Create mock LLM objects
     mock_llm1 = Mock(spec=LLM)
+    mock_llm1.service_id = "service1"
     mock_llm2 = Mock(spec=LLM)
+    mock_llm2.service_id = "service2"
 
     # Mock the RegistryEvent to avoid LLM attribute access
     with patch("openhands.sdk.llm.llm_registry.RegistryEvent") as mock_registry_event:
         mock_registry_event.return_value = Mock()
 
         # Add some LLMs using the new API
-        registry.add("service1", mock_llm1)
-        registry.add("service2", mock_llm2)
+        registry.add(mock_llm1)
+        registry.add(mock_llm2)
 
         # Test list_services
         services = registry.list_services()
@@ -108,26 +110,26 @@ def test_llm_registry_add_method():
 
     # Create a mock LLM
     mock_llm = Mock(spec=LLM)
-    service_id = "test-service"
+    mock_llm.service_id = "test-service"
+    service_id = mock_llm.service_id
 
     # Mock the RegistryEvent to avoid LLM attribute access
     with patch("openhands.sdk.llm.llm_registry.RegistryEvent") as mock_registry_event:
         mock_registry_event.return_value = Mock()
 
         # Test adding an LLM
-        registry.add(service_id, mock_llm)
+        registry.add(mock_llm)
 
         # Verify the LLM was added
         assert service_id in registry.service_to_llm
         assert registry.service_to_llm[service_id] is mock_llm
-        assert mock_llm.service_id == service_id
 
         # Verify RegistryEvent was called
-        mock_registry_event.assert_called_once_with(llm=mock_llm, service_id=service_id)
+        mock_registry_event.assert_called_once_with(llm=mock_llm)
 
     # Test that adding the same service_id raises ValueError
     with unittest.TestCase().assertRaises(ValueError) as context:
-        registry.add(service_id, mock_llm)
+        registry.add(mock_llm)
 
     assert "already exists in registry" in str(context.exception)
 
@@ -138,14 +140,15 @@ def test_llm_registry_get_method():
 
     # Create a mock LLM
     mock_llm = Mock(spec=LLM)
-    service_id = "test-service"
+    mock_llm.service_id = "test-service"
+    service_id = mock_llm.service_id
 
     # Mock the RegistryEvent to avoid LLM attribute access
     with patch("openhands.sdk.llm.llm_registry.RegistryEvent") as mock_registry_event:
         mock_registry_event.return_value = Mock()
 
         # Add the LLM first
-        registry.add(service_id, mock_llm)
+        registry.add(mock_llm)
 
         # Test getting the LLM
         retrieved_llm = registry.get(service_id)
@@ -164,15 +167,17 @@ def test_llm_registry_add_get_workflow():
 
     # Create mock LLMs
     llm1 = Mock(spec=LLM)
+    llm1.service_id = "service1"
     llm2 = Mock(spec=LLM)
+    llm2.service_id = "service2"
 
     # Mock the RegistryEvent to avoid LLM attribute access
     with patch("openhands.sdk.llm.llm_registry.RegistryEvent") as mock_registry_event:
         mock_registry_event.return_value = Mock()
 
         # Add multiple LLMs
-        registry.add("service1", llm1)
-        registry.add("service2", llm2)
+        registry.add(llm1)
+        registry.add(llm2)
 
         # Verify we can retrieve them
         assert registry.get("service1") is llm1

--- a/tests/sdk/llm/test_llm_serialization.py
+++ b/tests/sdk/llm/test_llm_serialization.py
@@ -11,7 +11,12 @@ from openhands.sdk.llm.utils.metrics import Metrics
 def test_llm_basic_json_serialization() -> None:
     """Test that LLM supports basic JSON serialization/deserialization."""
     # Create LLM with basic configuration
-    llm = LLM(model="test-model", temperature=0.5, max_output_tokens=1000)
+    llm = LLM(
+        model="test-model",
+        temperature=0.5,
+        max_output_tokens=1000,
+        service_id="test-llm",
+    )
 
     # Serialize to JSON
     llm_json = llm.model_dump_json()
@@ -27,6 +32,7 @@ def test_llm_secret_fields_serialization() -> None:
     """Test that SecretStr fields are handled correctly during serialization."""
     # Create LLM with secret fields
     llm = LLM(
+        service_id="test-llm",
         model="test-model",
         api_key=SecretStr("secret-api-key"),
         aws_access_key_id=SecretStr("aws-access-key"),
@@ -63,7 +69,7 @@ def test_llm_secret_fields_serialization() -> None:
 def test_llm_excluded_fields_not_serialized() -> None:
     """Test that excluded fields are not included in serialization."""
     # Create LLM with excluded fields
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
 
     # Serialize to dict
     llm_dict = llm.model_dump()
@@ -78,7 +84,7 @@ def test_llm_excluded_fields_not_serialized() -> None:
 
     # Excluded fields should have default values
     # (LLM automatically creates metrics during init)
-    assert deserialized_llm.service_id == "default"
+    assert deserialized_llm.service_id == "test-llm"
     assert isinstance(
         deserialized_llm.metrics, Metrics
     )  # LLM creates metrics automatically
@@ -88,7 +94,7 @@ def test_llm_excluded_fields_not_serialized() -> None:
 def test_llm_private_attributes_not_serialized() -> None:
     """Test that private attributes are not included in serialization."""
     # Create LLM
-    llm = LLM(model="test-model")
+    llm = LLM(model="test-model", service_id="test-llm")
 
     # Set private attributes (these would normally be set internally)
     llm._model_info = {"some": "info"}
@@ -127,6 +133,7 @@ def test_llm_field_validation_during_deserialization() -> None:
         "temperature": 0.8,
         "num_retries": 3,
         "timeout": 30,
+        "service_id": "test-llm",
     }
 
     # Should deserialize successfully
@@ -145,7 +152,7 @@ def test_llm_supports_field_json_serialization() -> None:
         name: str
 
     # Create container with LLM
-    llm = LLM(model="test-model", temperature=0.3)
+    llm = LLM(model="test-model", temperature=0.3, service_id="test-llm")
     container = Container(llm=llm, name="test-container")
 
     # Serialize to JSON
@@ -170,8 +177,8 @@ def test_llm_supports_nested_json_serialization() -> None:
         config_name: str
 
     # Create container with multiple LLMs
-    llm1 = LLM(model="model-1", temperature=0.1)
-    llm2 = LLM(model="model-2", temperature=0.9)
+    llm1 = LLM(model="model-1", temperature=0.1, service_id="test-llm")
+    llm2 = LLM(model="model-2", temperature=0.9, service_id="test-llm")
     container = NestedContainer(llms=[llm1, llm2], config_name="multi-llm")
 
     # Serialize to JSON
@@ -196,7 +203,7 @@ def test_llm_supports_nested_json_serialization() -> None:
 def test_llm_model_validate_json_dict() -> None:
     """Test that LLM.model_validate works with dict from JSON."""
     # Create LLM
-    llm = LLM(model="test-model", top_p=0.95)
+    llm = LLM(model="test-model", top_p=0.95, service_id="test-llm")
 
     # Serialize to JSON, then parse to dict
     llm_json = llm.model_dump_json()

--- a/tests/sdk/preset/test_default_preset.py
+++ b/tests/sdk/preset/test_default_preset.py
@@ -14,7 +14,7 @@ from openhands.sdk.tool.spec import ToolSpec
 @pytest.fixture
 def basic_llm():
     """Create a basic LLM for testing."""
-    return LLM(model="test-model")
+    return LLM(model="test-model", service_id="test-llm")
 
 
 def test_get_default_agent_includes_browser_toolset(basic_llm):


### PR DESCRIPTION
This PR 

1. Remove the default `service_id` from `LLM` to encourage explicit service scoping.

2. Drop the `service_id` parameter from `LLMRegistry`; the `LLM` already carries its own ID, eliminating redundancy 

3. Update tests and examples to set `service_id` explicitly.



#### Tradeoffs 
Users must now pass an explicit `service_id` when instantiating an LLM. Aside from this constructor change, the public API for `LLM` and `LLMRegistry` remain the same. Standalone `LLM` instances still work as before, and `LLMRegistry` continues to reject duplicate `service_ids`.


---

**Agent Server image for this PR**

Pull (multi-arch manifest):
```bash
docker pull ghcr.io/all-hands-ai/agent-server:26f6396
```

Run:
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-26f6396 \
  ghcr.io/all-hands-ai/agent-server:26f6396
```

_This tag is a multi-arch manifest (amd64/arm64). Your client pulls the right arch automatically._