### PR TITLE
Fix quoted 'Self' type annotations

### DIFF
--- a/openhands/sdk/tool/tool.py
+++ b/openhands/sdk/tool/tool.py
@@ -118,7 +118,7 @@ class ToolBase[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
     )
 
     @classmethod
-    def create(cls, *args, **kwargs) -> Sequence["Self"]:
+    def create(cls, *args, **kwargs) -> Sequence[Self]:
         """Create a sequence of Tool instances. Placeholder for subclasses.
 
         This can be overridden in subclasses to provide custom initialization logic

--- a/openhands/tools/browser_use/definition.py
+++ b/openhands/tools/browser_use/definition.py
@@ -90,7 +90,7 @@ class BrowserNavigateTool(Tool[BrowserNavigateAction, BrowserObservation]):
     """Tool for browser navigation."""
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_navigate_tool.name,
@@ -149,7 +149,7 @@ class BrowserClickTool(Tool[BrowserClickAction, BrowserObservation]):
     """Tool for clicking browser elements."""
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_click_tool.name,
@@ -205,7 +205,7 @@ class BrowserTypeTool(Tool[BrowserTypeAction, BrowserObservation]):
     """Tool for typing text into browser elements."""
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_type_tool.name,
@@ -258,7 +258,7 @@ class BrowserGetStateTool(Tool[BrowserGetStateAction, BrowserObservation]):
     """Tool for getting browser state."""
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_get_state_tool.name,
@@ -312,7 +312,7 @@ class BrowserGetContentTool(Tool[BrowserGetContentAction, BrowserObservation]):
     """Tool for getting page content in markdown."""
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_get_content_tool.name,
@@ -365,7 +365,7 @@ class BrowserScrollTool(Tool[BrowserScrollAction, BrowserObservation]):
     """Tool for scrolling the browser page."""
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_scroll_tool.name,
@@ -412,7 +412,7 @@ class BrowserGoBackTool(Tool[BrowserGoBackAction, BrowserObservation]):
     """Tool for going back in browser history."""
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_go_back_tool.name,
@@ -459,7 +459,7 @@ class BrowserListTabsTool(Tool[BrowserListTabsAction, BrowserObservation]):
     """Tool for listing browser tabs."""
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_list_tabs_tool.name,
@@ -514,7 +514,7 @@ class BrowserSwitchTabTool(Tool[BrowserSwitchTabAction, BrowserObservation]):
     # instances
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_switch_tab_tool.name,
@@ -565,7 +565,7 @@ class BrowserCloseTabTool(Tool[BrowserCloseTabAction, BrowserObservation]):
     """Tool for closing browser tabs."""
 
     @classmethod
-    def create(cls, executor: "BrowserToolExecutor") -> Sequence["Self"]:
+    def create(cls, executor: "BrowserToolExecutor") -> Sequence[Self]:
         return [
             cls(
                 name=browser_close_tab_tool.name,


### PR DESCRIPTION
## Summary

This PR fixes issue #487 by replacing quoted `"Self"` with proper `Self` type annotations in return types.

## Changes Made

- **openhands/sdk/tool/tool.py**: Fixed `ToolBase.create()` method return type annotation
- **openhands/tools/browser_use/definition.py**: Fixed all browser tool `create()` method return type annotations (10 instances)

## Details

The issue was that some type annotations were using `"Self"` (with quotes) instead of `Self` (without quotes). This is incorrect Python typing syntax. The proper way to reference the current class type is to use `Self` directly, which is imported from `typing`.

## Testing

- ✅ All pre-commit hooks pass (ruff format, ruff lint, pycodestyle, pyright type checking)
- ✅ All SDK tool tests pass (68 tests)
- ✅ All browser tool tests pass (42 tests)
- ✅ No functionality changes - purely a type annotation fix

## Files Changed

- `openhands/sdk/tool/tool.py` (1 change)
- `openhands/tools/browser_use/definition.py` (10 changes)

Fixes #487

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/19611ac00ee7486aaf4984815f10964d)