### PR TITLE
Remove pandas from dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ openhands-agent-server = { workspace = true }
 
 [dependency-groups]
 dev = [
-    "pandas>=2.0.0",
     "pre-commit>=4.3.0",
     "psutil>=7.0.0",
     "pyright[nodejs]>=1.1.405",

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,6 @@ members = [
 
 [manifest.dependency-groups]
 dev = [
-    { name = "pandas", specifier = ">=2.0.0" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pycodestyle", specifier = ">=2.12.0" },


### PR DESCRIPTION
## Summary

This PR removes `pandas>=2.0.0` from the dev dependencies in `pyproject.toml` as it's not being used in the codebase and is already excluded from the PyInstaller build.

## Changes Made

- **pyproject.toml**: Removed `"pandas>=2.0.0"` from the `[dependency-groups]` dev section
- **uv.lock**: Updated lock file to reflect the removal of pandas from dev dependencies

## Rationale

- pandas was listed in dev dependencies but is already excluded in `agent-server.spec` (line 62)
- The package is not used anywhere in the codebase
- Removing it reduces unnecessary dependencies and potential security surface area
- The PyInstaller build already excludes pandas, so this change aligns the dev dependencies with the actual usage

## Testing

- ✅ `uv lock` completed successfully
- ✅ Pre-commit hooks passed
- ✅ No functionality should be affected as pandas was not being used

## Type of Change

- [x] Dependency update/cleanup
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7d1c58bd523a47c9b91635238d00061b)