### PR TITLE
Fix LLM service_id naming inconsistencies in examples

### DIFF
--- a/examples/01_hello_world.py
+++ b/examples/01_hello_world.py
@@ -21,7 +21,7 @@ llm = LLM(
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
-    service_id="hello-world-llm",
+    service_id="agent",
 )
 
 cwd = os.getcwd()

--- a/examples/02_custom_tools.py
+++ b/examples/02_custom_tools.py
@@ -119,7 +119,7 @@ _GREP_DESCRIPTION = """Fast content search tool.
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/03_activate_microagent.py
+++ b/examples/03_activate_microagent.py
@@ -26,7 +26,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/04_confirmation_mode_example.py
+++ b/examples/04_confirmation_mode_example.py
@@ -81,7 +81,7 @@ def run_until_finished(conversation: BaseConversation, confirmer: Callable) -> N
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/05_use_llm_registry.py
+++ b/examples/05_use_llm_registry.py
@@ -25,7 +25,7 @@ assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 # Create LLM instance
 main_llm = LLM(
-    service_id="primary-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
@@ -36,7 +36,7 @@ llm_registry = LLMRegistry()
 llm_registry.add(main_llm)
 
 # Get LLM from registry
-llm = llm_registry.get("main_agent")
+llm = llm_registry.get("agent")
 
 # Tools
 cwd = os.getcwd()
@@ -68,7 +68,7 @@ print("=" * 100)
 print(f"LLM Registry services: {llm_registry.list_services()}")
 
 # Demonstrate getting the same LLM instance from registry
-same_llm = llm_registry.get("main_agent")
+same_llm = llm_registry.get("agent")
 print(f"Same LLM instance: {llm is same_llm}")
 
 # Demonstrate requesting a completion directly from an LLM

--- a/examples/06_interactive_terminal_w_reasoning.py
+++ b/examples/06_interactive_terminal_w_reasoning.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     # model="litellm_proxy/gemini/gemini-2.5-pro",
     model="litellm_proxy/deepseek/deepseek-reasoner",
     base_url="https://llm-proxy.eval.all-hands.dev",

--- a/examples/07_mcp_integration.py
+++ b/examples/07_mcp_integration.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/08_mcp_with_oauth.py
+++ b/examples/08_mcp_with_oauth.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/09_pause_example.py
+++ b/examples/09_pause_example.py
@@ -19,7 +19,7 @@ from openhands.tools.str_replace_editor import FileEditorTool
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/10_persistence.py
+++ b/examples/10_persistence.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/11_async.py
+++ b/examples/11_async.py
@@ -31,7 +31,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/12_custom_secrets.py
+++ b/examples/12_custom_secrets.py
@@ -16,7 +16,7 @@ from openhands.tools.str_replace_editor import FileEditorTool
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="claude-sonnet-4-20250514",
     api_key=SecretStr(api_key),
 )

--- a/examples/13_get_llm_metrics.py
+++ b/examples/13_get_llm_metrics.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/14_context_condenser.py
+++ b/examples/14_context_condenser.py
@@ -31,7 +31,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/15_browser_use.py
+++ b/examples/15_browser_use.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/18_send_message_while_processing.py
+++ b/examples/18_send_message_while_processing.py
@@ -59,7 +59,7 @@ from openhands.tools.str_replace_editor import FileEditorTool
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/19_llm_routing.py
+++ b/examples/19_llm_routing.py
@@ -24,13 +24,13 @@ api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 primary_llm = LLM(
-    service_id="primary-llm",
+    service_id="agent-primary",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
 )
 secondary_llm = LLM(
-    service_id="secondary-llm",
+    service_id="agent-secondary",
     model="litellm_proxy/mistral/devstral-small-2507",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/20_stuck_detector.py
+++ b/examples/20_stuck_detector.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/21_generate_extraneous_conversation_costs.py
+++ b/examples/21_generate_extraneous_conversation_costs.py
@@ -27,7 +27,7 @@ assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 # Create LLM instance
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
@@ -66,7 +66,7 @@ conversation.run()
 
 # Demonstrate extraneous costs part of the conversation
 second_llm = LLM(
-    service_id="secondary-llm",
+    service_id="demo-secondary",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/22_hello_world_with_agent_server.py
+++ b/examples/22_hello_world_with_agent_server.py
@@ -122,7 +122,7 @@ api_key = os.getenv("LITELLM_API_KEY")
 assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
 llm = LLM(
-    service_id="main-llm",
+    service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),

--- a/examples/23_hello_world_with_sandboxed_server.py
+++ b/examples/23_hello_world_with_sandboxed_server.py
@@ -43,7 +43,7 @@ def main() -> None:
     assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
 
     llm = LLM(
-        service_id="main-llm",
+        service_id="agent",
         model="litellm_proxy/anthropic/claude-sonnet-4-20250514",
         base_url="https://llm-proxy.eval.all-hands.dev",
         api_key=SecretStr(api_key),


### PR DESCRIPTION
## Problem

Example 5 (`05_use_llm_registry.py`) had a service_id mismatch that caused a KeyError:
- LLM was registered with service_id `"primary-llm"`
- But code attempted to retrieve it using `"main_agent"`

This highlighted inconsistent naming conventions across all examples.

## Solution

**Fixed the immediate issue:**
- Changed example 5 to use consistent `"agent"` service_id for both registration and retrieval

**Standardized naming conventions across all examples:**
- Agent-related LLMs now use `"agent"` service_id (changed from `"main-llm"`, `"hello-world-llm"`)
- Condenser LLMs continue using `"condenser"` service_id (already correct)
- Specialized LLMs keep descriptive names (`"security-analyzer"`, `"vision-llm"`, `"multimodal-router"`)
- Multi-purpose examples use descriptive prefixes (`"agent-primary"`, `"agent-secondary"`, `"demo-secondary"`)

## Changes

- **21 example files updated** with consistent service_id naming
- **Example 5**: Fixed KeyError by using `"agent"` for both registration and retrieval
- **18 files**: Changed `"main-llm"` → `"agent"`
- **1 file**: Changed `"hello-world-llm"` → `"agent"`
- **Routing example**: Updated to `"agent-primary"` and `"agent-secondary"`
- **Demo example**: Changed to `"demo-secondary"`

## Testing

- All pre-commit hooks pass (formatting, linting, type checking)
- Example 5 now works correctly (verified up to API key requirement)
- No functional changes, only service_id naming standardization

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c6d6b2a4da0848dc9512e2f999d3f985)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:74ffdee-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-74ffdee-python \
  ghcr.io/all-hands-ai/agent-server:74ffdee-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:74ffdee-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:74ffdee-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:74ffdee-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `74ffdee` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->