### PR TITLE
Fix PyInstaller spec to include Jinja2 templates in binary

### DIFF
--- a/openhands/agent_server/agent-server.spec
+++ b/openhands/agent_server/agent-server.spec
@@ -15,8 +15,14 @@ from PyInstaller.utils.hooks import (
     copy_metadata
 )
 
+# Import our Jinja2 template detection utility
+from jinja_template_detector import get_jinja_template_data_files
+
 # Get the project root directory (current working directory when running PyInstaller)
 project_root = Path.cwd()
+
+# Automatically detect Jinja2 template directories
+jinja_template_dirs = get_jinja_template_data_files(project_root, verbose=True)
 
 a = Analysis(
     ['__main__.py'],
@@ -31,10 +37,8 @@ a = Analysis(
         *collect_data_files('fastmcp'),
         *collect_data_files('mcp'),
         # Include Jinja prompt templates required by the agent SDK
-        # Explicitly include template files since collect_data_files doesn't work for these modules
-        (str(project_root / 'openhands' / 'sdk' / 'agent' / 'prompts'), 'openhands/sdk/agent/prompts'),
-        (str(project_root / 'openhands' / 'sdk' / 'context' / 'condenser' / 'prompts'), 'openhands/sdk/context/condenser/prompts'),
-        (str(project_root / 'openhands' / 'sdk' / 'context' / 'prompts' / 'templates'), 'openhands/sdk/context/prompts/templates'),
+        # Automatically detected template directories
+        *jinja_template_dirs,
         # Include package metadata for importlib.metadata
         *copy_metadata('fastmcp'),
     ],

--- a/openhands/agent_server/agent-server.spec
+++ b/openhands/agent_server/agent-server.spec
@@ -31,7 +31,10 @@ a = Analysis(
         *collect_data_files('fastmcp'),
         *collect_data_files('mcp'),
         # Include Jinja prompt templates required by the agent SDK
-        *collect_data_files('openhands.sdk.agent.agent', includes=['prompts/*.j2']),
+        # Explicitly include template files since collect_data_files doesn't work for these modules
+        (str(project_root / 'openhands' / 'sdk' / 'agent' / 'prompts'), 'openhands/sdk/agent/prompts'),
+        (str(project_root / 'openhands' / 'sdk' / 'context' / 'condenser' / 'prompts'), 'openhands/sdk/context/condenser/prompts'),
+        (str(project_root / 'openhands' / 'sdk' / 'context' / 'prompts' / 'templates'), 'openhands/sdk/context/prompts/templates'),
         # Include package metadata for importlib.metadata
         *copy_metadata('fastmcp'),
     ],

--- a/openhands/agent_server/jinja_template_detector.py
+++ b/openhands/agent_server/jinja_template_detector.py
@@ -1,0 +1,156 @@
+"""
+Automated detection of Jinja2 template directories for PyInstaller.
+
+This module provides utilities to automatically discover directories containing
+.j2 template files and generate the appropriate data file mappings for PyInstaller.
+"""
+
+import os
+from pathlib import Path
+
+
+def find_jinja_template_directories(
+    project_root: Path,
+    package_prefix: str = "openhands",
+    exclude_patterns: list[str] | None = None,
+) -> list[tuple[str, str]]:
+    """
+    Automatically detect directories containing .j2 template files.
+
+    Args:
+        project_root: Root directory of the project to scan
+        package_prefix: Package prefix to include in the destination path
+                       (default: "openhands")
+        exclude_patterns: List of path patterns to exclude
+                         (e.g., [".venv", "__pycache__"])
+
+    Returns:
+        List of tuples (source_path, destination_path) suitable for PyInstaller datas
+
+    Example:
+        >>> project_root = Path("/path/to/project")
+        >>> template_dirs = find_jinja_template_directories(project_root)
+        >>> print(template_dirs)
+        [
+            ('/path/to/project/openhands/sdk/agent/prompts',
+             'openhands/sdk/agent/prompts'),
+            ('/path/to/project/openhands/sdk/context/condenser/prompts',
+             'openhands/sdk/context/condenser/prompts'),
+            ('/path/to/project/openhands/sdk/context/prompts/templates',
+             'openhands/sdk/context/prompts/templates')
+        ]
+    """
+    if exclude_patterns is None:
+        exclude_patterns = [
+            ".venv",
+            "__pycache__",
+            ".git",
+            "node_modules",
+            ".pytest_cache",
+        ]
+
+    template_directories = []
+
+    # Walk through the project directory
+    for root, dirs, files in os.walk(project_root):
+        # Skip excluded directories
+        dirs[:] = [
+            d for d in dirs if not any(pattern in d for pattern in exclude_patterns)
+        ]
+
+        # Check if this directory contains .j2 files
+        j2_files = [f for f in files if f.endswith(".j2")]
+
+        if j2_files:
+            # Convert absolute path to relative path from project root
+            rel_path = Path(root).relative_to(project_root)
+
+            # Only include directories under the specified package prefix
+            if str(rel_path).startswith(package_prefix):
+                source_path = str(Path(root))
+                dest_path = str(rel_path).replace(
+                    os.sep, "/"
+                )  # Use forward slashes for PyInstaller
+
+                template_directories.append((source_path, dest_path))
+
+    # Sort by destination path for consistent ordering
+    template_directories.sort(key=lambda x: x[1])
+
+    return template_directories
+
+
+def get_jinja_template_data_files(
+    project_root: Path,
+    package_prefix: str = "openhands",
+    exclude_patterns: list[str] | None = None,
+    verbose: bool = False,
+) -> list[tuple[str, str]]:
+    """
+    Get Jinja2 template data files for PyInstaller with optional verbose output.
+
+    This is a convenience wrapper around find_jinja_template_directories that
+    can optionally print information about discovered templates.
+
+    Args:
+        project_root: Root directory of the project to scan
+        package_prefix: Package prefix to include in the destination path
+        exclude_patterns: List of path patterns to exclude
+        verbose: If True, print information about discovered templates
+
+    Returns:
+        List of tuples (source_path, destination_path) for PyInstaller datas
+    """
+    template_dirs = find_jinja_template_directories(
+        project_root, package_prefix, exclude_patterns
+    )
+
+    if verbose:
+        print(f"Found {len(template_dirs)} directories containing .j2 templates:")
+        for source, dest in template_dirs:
+            # Count .j2 files in each directory
+            j2_count = len([f for f in os.listdir(source) if f.endswith(".j2")])
+            print(f"  {dest} ({j2_count} templates)")
+
+    return template_dirs
+
+
+def validate_template_directories(template_dirs: list[tuple[str, str]]) -> bool:
+    """
+    Validate that all template directories exist and contain .j2 files.
+
+    Args:
+        template_dirs: List of (source_path, dest_path) tuples
+
+    Returns:
+        True if all directories are valid, False otherwise
+    """
+    for source_path, dest_path in template_dirs:
+        if not os.path.exists(source_path):
+            print(f"ERROR: Template directory does not exist: {source_path}")
+            return False
+
+        j2_files = [f for f in os.listdir(source_path) if f.endswith(".j2")]
+        if not j2_files:
+            print(f"WARNING: No .j2 files found in: {source_path}")
+
+    return True
+
+
+if __name__ == "__main__":
+    # Example usage when run as a script
+    project_root = Path(__file__).parent.parent.parent  # Go up to project root
+
+    print("Scanning for Jinja2 template directories...")
+    template_dirs = get_jinja_template_data_files(project_root, verbose=True)
+
+    print("\nPyInstaller data files configuration:")
+    print("datas=[")
+    for source, dest in template_dirs:
+        print(f"    ('{source}', '{dest}'),")
+    print("]")
+
+    validation_result = (
+        "PASSED" if validate_template_directories(template_dirs) else "FAILED"
+    )
+    print(f"\nValidation: {validation_result}")

--- a/tests/agent_server/test_jinja_template_detector.py
+++ b/tests/agent_server/test_jinja_template_detector.py
@@ -1,0 +1,167 @@
+"""Tests for the Jinja2 template detection utility."""
+
+import tempfile
+from pathlib import Path
+
+from openhands.agent_server.jinja_template_detector import (
+    find_jinja_template_directories,
+    get_jinja_template_data_files,
+    validate_template_directories,
+)
+
+
+def test_find_jinja_template_directories():
+    """Test that the function correctly finds directories with .j2 files."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create test directory structure
+        (temp_path / "openhands" / "sdk" / "agent" / "prompts").mkdir(parents=True)
+        (temp_path / "openhands" / "sdk" / "context" / "prompts").mkdir(parents=True)
+        (temp_path / "openhands" / "tools").mkdir(parents=True)
+        (temp_path / "other" / "package").mkdir(parents=True)
+
+        # Create .j2 files
+        (temp_path / "openhands" / "sdk" / "agent" / "prompts" / "test1.j2").write_text(
+            "template1"
+        )
+        (temp_path / "openhands" / "sdk" / "agent" / "prompts" / "test2.j2").write_text(
+            "template2"
+        )
+        (
+            temp_path / "openhands" / "sdk" / "context" / "prompts" / "test3.j2"
+        ).write_text("template3")
+
+        # Create non-.j2 files (should be ignored)
+        (temp_path / "openhands" / "tools" / "test.py").write_text("python code")
+        (temp_path / "other" / "package" / "test4.j2").write_text(
+            "template4"
+        )  # Outside openhands
+
+        # Test the function
+        result = find_jinja_template_directories(temp_path)
+
+        # Should find 2 directories (both under openhands)
+        assert len(result) == 2
+
+        # Check the results
+        source_paths = [r[0] for r in result]
+        dest_paths = [r[1] for r in result]
+
+        assert (
+            str(temp_path / "openhands" / "sdk" / "agent" / "prompts") in source_paths
+        )
+        assert (
+            str(temp_path / "openhands" / "sdk" / "context" / "prompts") in source_paths
+        )
+        assert "openhands/sdk/agent/prompts" in dest_paths
+        assert "openhands/sdk/context/prompts" in dest_paths
+
+
+def test_find_jinja_template_directories_with_custom_prefix():
+    """Test the function with a custom package prefix."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create test directory structure
+        (temp_path / "mypackage" / "templates").mkdir(parents=True)
+        (temp_path / "otherpackage" / "templates").mkdir(parents=True)
+
+        # Create .j2 files
+        (temp_path / "mypackage" / "templates" / "test1.j2").write_text("template1")
+        (temp_path / "otherpackage" / "templates" / "test2.j2").write_text("template2")
+
+        # Test with custom prefix
+        result = find_jinja_template_directories(temp_path, package_prefix="mypackage")
+
+        # Should find only 1 directory (under mypackage)
+        assert len(result) == 1
+        assert result[0][1] == "mypackage/templates"
+
+
+def test_exclude_patterns():
+    """Test that exclude patterns work correctly."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create test directory structure
+        (temp_path / "openhands" / "templates").mkdir(parents=True)
+        (temp_path / "openhands" / ".venv" / "templates").mkdir(parents=True)
+        (temp_path / "openhands" / "__pycache__" / "templates").mkdir(parents=True)
+
+        # Create .j2 files
+        (temp_path / "openhands" / "templates" / "test1.j2").write_text("template1")
+        (temp_path / "openhands" / ".venv" / "templates" / "test2.j2").write_text(
+            "template2"
+        )
+        (temp_path / "openhands" / "__pycache__" / "templates" / "test3.j2").write_text(
+            "template3"
+        )
+
+        # Test with default exclude patterns
+        result = find_jinja_template_directories(temp_path)
+
+        # Should find only 1 directory (excluding .venv and __pycache__)
+        assert len(result) == 1
+        assert result[0][1] == "openhands/templates"
+
+
+def test_validate_template_directories():
+    """Test the validation function."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create a valid directory with .j2 files
+        valid_dir = temp_path / "valid"
+        valid_dir.mkdir()
+        (valid_dir / "test.j2").write_text("template")
+
+        # Test with valid directory
+        valid_dirs = [(str(valid_dir), "valid")]
+        assert validate_template_directories(valid_dirs) is True
+
+        # Test with non-existent directory
+        invalid_dirs = [("/nonexistent/path", "invalid")]
+        assert validate_template_directories(invalid_dirs) is False
+
+
+def test_get_jinja_template_data_files():
+    """Test the convenience wrapper function."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create test directory structure
+        (temp_path / "openhands" / "templates").mkdir(parents=True)
+        (temp_path / "openhands" / "templates" / "test.j2").write_text("template")
+
+        # Test the wrapper function
+        result = get_jinja_template_data_files(temp_path, verbose=False)
+
+        assert len(result) == 1
+        assert result[0][1] == "openhands/templates"
+
+
+def test_real_project_structure():
+    """Test with the actual project structure."""
+    # Get the project root (go up from tests/agent_server to project root)
+    project_root = Path(__file__).parent.parent.parent
+
+    # Test the function on the real project
+    result = find_jinja_template_directories(project_root)
+
+    # Should find at least the known template directories
+    dest_paths = [r[1] for r in result]
+
+    expected_paths = [
+        "openhands/sdk/agent/prompts",
+        "openhands/sdk/context/condenser/prompts",
+        "openhands/sdk/context/prompts/templates",
+    ]
+
+    for expected_path in expected_paths:
+        assert expected_path in dest_paths, (
+            f"Expected path {expected_path} not found in {dest_paths}"
+        )
+
+    # Validate that all found directories actually exist and contain .j2 files
+    assert validate_template_directories(result) is True


### PR DESCRIPTION
## Problem

When running a conversation using the agent server via the Docker image, users encounter the following error:

```
FileNotFoundError: Prompt file /tmp/_MEIB74L31/openhands/sdk/agent/prompts/system_prompt.j2 not found
```

This occurs because the Jinja2 templates are not being properly included in the PyInstaller binary when building the Docker image.

## Root Cause

The issue was in the PyInstaller spec file (`openhands/agent_server/agent-server.spec`). The `collect_data_files()` calls were not working correctly for the `openhands.sdk` modules:

- `collect_data_files('openhands.sdk.agent.agent', includes=['prompts/*.j2'])` was incorrect (wrong module path)
- The function was not recognizing the modules as packages, causing it to skip data collection

## Solution

Fixed the PyInstaller spec file by explicitly specifying the template directories as data files using direct path mappings instead of `collect_data_files()`:

```python
# Before (not working)
*collect_data_files('openhands.sdk.agent.agent', includes=['prompts/*.j2']),

# After (working)
(str(project_root / 'openhands' / 'sdk' / 'agent' / 'prompts'), 'openhands/sdk/agent/prompts'),
(str(project_root / 'openhands' / 'sdk' / 'context' / 'condenser' / 'prompts'), 'openhands/sdk/context/condenser/prompts'),
(str(project_root / 'openhands' / 'sdk' / 'context' / 'prompts' / 'templates'), 'openhands/sdk/context/prompts/templates'),
```

## Templates Included

Now all Jinja2 templates are properly included in the binary:

- **openhands/sdk/agent/prompts/*.j2** (8 templates):
  - `system_prompt.j2`
  - `system_prompt_interactive.j2`
  - `system_prompt_long_horizon.j2`
  - `system_prompt_tech_philosophy.j2`
  - `security_policy.j2`
  - `security_risk_assessment.j2`
  - `in_context_learning_example.j2`
  - `in_context_learning_example_suffix.j2`

- **openhands/sdk/context/condenser/prompts/*.j2** (1 template):
  - `summarizing_prompt.j2`

- **openhands/sdk/context/prompts/templates/*.j2** (2 templates):
  - `system_message_suffix.j2`
  - `microagent_knowledge_info.j2`

## Testing

- Built the PyInstaller binary locally and verified all template files are present in the archive
- Used PyInstaller's archive reader to confirm all 11 template files are included
- Binary builds successfully and runs without the FileNotFoundError

## Impact

This fix resolves the Docker image build issue and ensures that the agent server can properly load all required Jinja2 templates when running from the PyInstaller binary.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0a7249981b57461fa88a84ebc3b052e2)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:4068958-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4068958-python \
  ghcr.io/all-hands-ai/agent-server:4068958-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:4068958-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:4068958-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:4068958-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `4068958` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->