### PR TITLE
Fix sandbox build script lookup to work from any directory

### DIFF
--- a/openhands/sdk/sandbox/docker.py
+++ b/openhands/sdk/sandbox/docker.py
@@ -97,14 +97,14 @@ def _resolve_build_script() -> Path | None:
     except Exception:
         pass
 
-    # Try common project layouts relative to CWD and this file
+    # Try common project layouts relative to this file and CWD
     candidates: list[Path] = [
-        Path.cwd() / "openhands" / "agent_server" / "docker" / "build.sh",
         Path(__file__).resolve().parents[3]
         / "openhands"
         / "agent_server"
         / "docker"
         / "build.sh",
+        Path.cwd() / "openhands" / "agent_server" / "docker" / "build.sh",
     ]
     for c in candidates:
         if c.exists():


### PR DESCRIPTION
Prioritize Path(__file__) over Path.cwd() when resolving build.sh location. This allows the agent server sandbox to be called from other repos or different working directories without failing to find the build script.

In particular this allows to run the script from the benchmarks directory.

Changes:
- Reorder candidates list to check file-relative path first
- Update comment to reflect new priority order
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:79cb4c0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-79cb4c0-python \
  ghcr.io/all-hands-ai/agent-server:79cb4c0-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:79cb4c0-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:79cb4c0-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:79cb4c0-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `79cb4c0` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->