### PR TITLE
Add add_session_api_key_header flag to WebhookSpec

### DIFF
--- a/openhands/agent_server/config.py
+++ b/openhands/agent_server/config.py
@@ -39,6 +39,13 @@ class WebhookSpec(BaseModel):
             "new event."
         ),
     )
+    add_session_api_key_header: bool = Field(
+        default=True,
+        description=(
+            "Whether to add the X-Session-API-Key header to POST requests. "
+            "When True, the session API key will be included in webhook requests."
+        ),
+    )
 
     # Retry parameters
     num_retries: int = Field(

--- a/openhands/agent_server/conversation_service.py
+++ b/openhands/agent_server/conversation_service.py
@@ -360,7 +360,7 @@ class WebhookSubscriber(Subscriber):
 
         # Prepare headers
         headers = self.spec.headers.copy()
-        if self.session_api_key:
+        if self.session_api_key and self.spec.add_session_api_key_header:
             headers["X-Session-API-Key"] = self.session_api_key
 
         # Convert events to serializable format
@@ -440,7 +440,7 @@ class ConversationWebhookSubscriber:
         """Post conversation info to the webhook immediately (no batching)."""
         # Prepare headers
         headers = self.spec.headers.copy()
-        if self.session_api_key:
+        if self.session_api_key and self.spec.add_session_api_key_header:
             headers["X-Session-API-Key"] = self.session_api_key
 
         # Construct conversations URL


### PR DESCRIPTION
## Summary

This PR adds a boolean flag `add_session_api_key_header` to the `WebhookSpec` class that controls whether the `X-Session-API-Key` header is added to POST requests in webhook subscribers.

## Changes

### Core Implementation
- **WebhookSpec Configuration** (`openhands/agent_server/config.py`):
  - Added `add_session_api_key_header: bool` field with default value `True`
  - Added comprehensive documentation explaining the field's purpose

- **WebhookSubscriber Updates** (`openhands/agent_server/conversation_service.py`):
  - Modified `WebhookSubscriber._post_events()` to conditionally add the `X-Session-API-Key` header based on both the session API key presence AND the new flag
  - Modified `ConversationWebhookSubscriber.post_conversation_info()` with the same conditional logic

### Testing
- **Comprehensive Test Coverage** (`tests/agent_server/test_webhook_subscriber.py`):
  - Added tests for WebhookSpec default and custom values
  - Added tests for WebhookSubscriber with the flag disabled
  - Added tests for ConversationWebhookSubscriber with the flag disabled
  - All existing tests continue to pass, ensuring backward compatibility

## Key Features

- **Backward Compatible**: Defaults to `True`, so existing configurations continue to work as before
- **Flexible Control**: Users can now disable the session API key header by setting `add_session_api_key_header=False`
- **Consistent Implementation**: Both event webhooks and conversation webhooks respect the flag
- **Well Tested**: Comprehensive test coverage ensures reliability

## Usage Examples

```python
# Default behavior - header is added (backward compatible)
webhook_spec = WebhookSpec(base_url="https://example.com")

# Explicitly disable the session API key header
webhook_spec = WebhookSpec(
    base_url="https://example.com",
    add_session_api_key_header=False
)

# Explicitly enable the session API key header
webhook_spec = WebhookSpec(
    base_url="https://example.com", 
    add_session_api_key_header=True
)
```

## Behavior

The implementation ensures that:
- When `add_session_api_key_header=True` (default) and a session API key is provided, the `X-Session-API-Key` header is added
- When `add_session_api_key_header=False`, the `X-Session-API-Key` header is never added, regardless of whether a session API key is provided
- When no session API key is provided, no header is added regardless of the flag value

## Testing

All pre-commit hooks pass and all tests are successful:
- 37/37 tests pass in the webhook subscriber test suite
- New functionality is thoroughly tested with 4 additional test methods
- Backward compatibility is maintained

Co-authored-by: openhands <openhands@all-hands.dev>

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/14a3f001e6b949d1b839b00641aaf34d)