### PR TITLE
chore: add runtime-safety microagent to discourage use of `set -e`

### DIFF
--- a/.openhands/microagents/runtime-safety.md
+++ b/.openhands/microagents/runtime-safety.md
@@ -1,0 +1,22 @@
+---
+name: Runtime Safety Reminder
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers: []
+---
+
+Purpose
+- Remind the assistant not to use `set -e` or any other `set` flags in this runtime environment. Just run commands directly; they will work as expected.
+
+Usage
+- This microagent has no triggers. It can be referenced explicitly by name when assembling context.
+- When executing shell commands, avoid adding shell options like `set -e`, `set -eu`, or `set -euo pipefail`.
+
+Guidance
+- For multi-step bash sequences, chain commands with `&&` or `;` as needed.
+- If a long-running command risks hanging, prefer background execution with output redirection (e.g., `cmd > out.log 2>&1 &`).
+- Do not alter global shell options in this environment.
+
+Limitations
+- This microagent provides guidance only; it does not execute commands itself.


### PR DESCRIPTION
Summary
- Add a new microagent to .openhands/microagents/runtime-safety.md that reminds contributors and automation not to use shell options like set -e in this runtime. The environment executes commands reliably without needing shell flags.

Details
- Microagent metadata included via YAML frontmatter (name, type, version, agent, triggers: []).
- No triggers are defined per requirements; the microagent is knowledge-only and can be included explicitly.
- Guidance clarifies preferred command chaining and background execution patterns, aligning with current tool runtime constraints.

Motivation
- Prevents brittle shell behavior and aligns with documented runtime guidance.

Testing/Checks
- Ran make build to ensure dev environment and hooks are configured.
- Ran pre-commit on the added file; no issues reported.

Notes
- No code changes beyond the microagent document.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/685f47e4e76f4d04a385f182c1f1f6f3)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:0452c01-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0452c01-python \
  ghcr.io/all-hands-ai/agent-server:0452c01-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:0452c01-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:0452c01-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:0452c01-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `0452c01` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->