### PR TITLE
Add API key support to RemoteConversation

### DIFF
--- a/openhands/sdk/conversation/conversation.py
+++ b/openhands/sdk/conversation/conversation.py
@@ -53,6 +53,7 @@ class Conversation:
         agent: AgentBase,
         *,
         host: str,
+        api_key: str | None = None,
         conversation_id: ConversationID | None = None,
         callbacks: list[ConversationCallbackType] | None = None,
         max_iteration_per_run: int = 500,
@@ -66,6 +67,7 @@ class Conversation:
         *,
         persist_filestore: FileStore | None = None,
         host: str | None = None,
+        api_key: str | None = None,
         conversation_id: ConversationID | None = None,
         callbacks: list[ConversationCallbackType] | None = None,
         max_iteration_per_run: int = 500,
@@ -81,6 +83,7 @@ class Conversation:
             return RemoteConversation(
                 agent=agent,
                 host=host,
+                api_key=api_key,
                 conversation_id=conversation_id,
                 callbacks=callbacks,
                 max_iteration_per_run=max_iteration_per_run,

--- a/tests/sdk/conversation/remote/test_api_key_functionality.py
+++ b/tests/sdk/conversation/remote/test_api_key_functionality.py
@@ -1,0 +1,198 @@
+"""Tests for API key functionality in RemoteConversation."""
+
+import uuid
+from unittest.mock import Mock, patch
+
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.impl.remote_conversation import (
+    RemoteConversation,
+    WebSocketCallbackClient,
+)
+from openhands.sdk.llm import LLM
+
+
+def create_test_agent() -> Agent:
+    """Create a test agent."""
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), service_id="test-llm")
+    return Agent(llm=llm, tools=[])
+
+
+def create_mock_http_responses():
+    """Create mock HTTP responses for RemoteConversation."""
+    # Mock the POST response for conversation creation
+    mock_post_response = Mock()
+    mock_post_response.raise_for_status.return_value = None
+    mock_post_response.json.return_value = {"id": str(uuid.uuid4())}
+
+    # Mock the GET response for events sync
+    mock_get_response = Mock()
+    mock_get_response.raise_for_status.return_value = None
+    mock_get_response.json.return_value = {"items": []}
+
+    return mock_post_response, mock_get_response
+
+
+def test_conversation_factory_passes_api_key_to_remote():
+    """Test that Conversation factory passes api_key to RemoteConversation."""
+    agent = create_test_agent()
+    test_api_key = "test-api-key-123"
+
+    with patch(
+        "openhands.sdk.conversation.impl.remote_conversation.RemoteConversation"
+    ) as mock_remote:
+        # Mock the RemoteConversation constructor
+        mock_instance = Mock()
+        mock_remote.return_value = mock_instance
+
+        # Create conversation with host and api_key
+        Conversation(
+            agent=agent,
+            host="http://localhost:3000",
+            api_key=test_api_key,
+        )
+
+        # Verify RemoteConversation was called with api_key
+        mock_remote.assert_called_once()
+        call_args = mock_remote.call_args
+        assert call_args.kwargs["api_key"] == test_api_key
+
+
+@patch("httpx.Client")
+def test_remote_conversation_configures_httpx_client_with_api_key(mock_httpx_client):
+    """Test that RemoteConversation configures httpx client with API key header."""
+    agent = create_test_agent()
+    test_api_key = "test-api-key-123"
+
+    # Mock httpx client and its responses
+    mock_client_instance = Mock()
+    mock_httpx_client.return_value = mock_client_instance
+
+    mock_post_response, mock_get_response = create_mock_http_responses()
+    mock_client_instance.post.return_value = mock_post_response
+    mock_client_instance.get.return_value = mock_get_response
+
+    with patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    ):
+        # Create RemoteConversation with API key
+        RemoteConversation(
+            agent=agent,
+            host="http://localhost:3000",
+            api_key=test_api_key,
+        )
+
+    # Verify httpx.Client was called with correct headers
+    mock_httpx_client.assert_called_once()
+    call_args = mock_httpx_client.call_args
+
+    # Check that headers were passed with the API key
+    assert "headers" in call_args.kwargs
+    headers = call_args.kwargs["headers"]
+    assert headers["X-Session-API-Key"] == test_api_key
+
+
+@patch("httpx.Client")
+def test_remote_conversation_no_api_key_no_headers(mock_httpx_client):
+    """Test that RemoteConversation doesn't add headers when no API key is provided."""
+    agent = create_test_agent()
+
+    # Mock httpx client and its responses
+    mock_client_instance = Mock()
+    mock_httpx_client.return_value = mock_client_instance
+
+    mock_post_response, mock_get_response = create_mock_http_responses()
+    mock_client_instance.post.return_value = mock_post_response
+    mock_client_instance.get.return_value = mock_get_response
+
+    with patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    ):
+        # Create RemoteConversation without API key
+        RemoteConversation(
+            agent=agent,
+            host="http://localhost:3000",
+            api_key=None,
+        )
+
+    # Verify httpx.Client was called without API key headers
+    mock_httpx_client.assert_called_once()
+    call_args = mock_httpx_client.call_args
+
+    # Check that headers were empty or don't contain API key
+    headers = call_args.kwargs.get("headers", {})
+    assert "X-Session-API-Key" not in headers
+
+
+def test_websocket_client_includes_api_key_in_url():
+    """Test that WebSocketCallbackClient includes API key in WebSocket URL."""
+    test_api_key = "test-api-key-123"
+    host = "http://localhost:3000"
+    conversation_id = str(uuid.uuid4())
+    callbacks = []
+
+    ws_client = WebSocketCallbackClient(
+        host=host,
+        conversation_id=conversation_id,
+        callbacks=callbacks,
+        api_key=test_api_key,
+    )
+
+    # Test the URL construction logic by checking the stored api_key
+    assert ws_client.api_key == test_api_key
+    assert ws_client.host == host
+    assert ws_client.conversation_id == conversation_id
+
+
+def test_websocket_client_no_api_key():
+    """Test that WebSocketCallbackClient works without API key."""
+    host = "http://localhost:3000"
+    conversation_id = str(uuid.uuid4())
+    callbacks = []
+
+    ws_client = WebSocketCallbackClient(
+        host=host,
+        conversation_id=conversation_id,
+        callbacks=callbacks,
+        api_key=None,
+    )
+
+    # Test that it works without API key
+    assert ws_client.api_key is None
+    assert ws_client.host == host
+    assert ws_client.conversation_id == conversation_id
+
+
+@patch("httpx.Client")
+def test_remote_conversation_passes_api_key_to_websocket_client(mock_httpx_client):
+    """Test that RemoteConversation passes API key to WebSocketCallbackClient."""
+    agent = create_test_agent()
+    test_api_key = "test-api-key-123"
+
+    # Mock httpx client and its responses
+    mock_client_instance = Mock()
+    mock_httpx_client.return_value = mock_client_instance
+
+    mock_post_response, mock_get_response = create_mock_http_responses()
+    mock_client_instance.post.return_value = mock_post_response
+    mock_client_instance.get.return_value = mock_get_response
+
+    with patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    ) as mock_ws_client:
+        mock_ws_instance = Mock()
+        mock_ws_client.return_value = mock_ws_instance
+
+        # Create RemoteConversation with API key
+        RemoteConversation(
+            agent=agent,
+            host="http://localhost:3000",
+            api_key=test_api_key,
+        )
+
+        # Verify WebSocketCallbackClient was called with api_key
+        mock_ws_client.assert_called_once()
+        call_args = mock_ws_client.call_args
+        assert call_args.kwargs["api_key"] == test_api_key


### PR DESCRIPTION
## Summary

This PR adds API key authentication support to the RemoteConversation class, allowing users to authenticate with the agent server using an API key.

## Changes Made

### Core Implementation
- **conversation.py**: Added `api_key` parameter to Conversation factory class overloads and `__new__` method
- **remote_conversation.py**: 
  - Added `api_key` parameter to RemoteConversation constructor
  - Configure httpx client with `X-Session-API-Key` header when API key is provided
  - Updated WebSocketCallbackClient to accept and use API key parameter
  - Include API key as `session_api_key` query parameter in WebSocket URL

### Testing
- Added comprehensive test suite in `test_api_key_functionality.py` covering:
  - API key parameter passing through the conversation factory
  - HTTP client header configuration
  - WebSocket client API key handling
  - Backward compatibility (no API key scenarios)

## Usage

```python
from openhands.sdk.conversation import Conversation

# With API key authentication
conversation = Conversation(
    agent=agent,
    host="http://localhost:3000",
    api_key="your-api-key-here"
)

# Without API key (existing behavior unchanged)
conversation = Conversation(
    agent=agent,
    host="http://localhost:3000"
)
```

## Authentication Flow

- **HTTP requests**: API key sent as `X-Session-API-Key` header
- **WebSocket connections**: API key sent as `session_api_key` query parameter

## Backward Compatibility

✅ All existing code continues to work without changes. The `api_key` parameter is optional and defaults to `None`.

## Testing

- All existing tests pass
- New tests provide comprehensive coverage of API key functionality
- Pre-commit hooks pass (ruff format, ruff lint, pycodestyle, pyright)

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/84012322a0fc4519adfbb83f3a71979e)