### PR TITLE
Fix sonnet3.5 recognition

### DIFF
--- a/openhands/sdk/llm/utils/model_features.py
+++ b/openhands/sdk/llm/utils/model_features.py
@@ -123,6 +123,7 @@ PROMPT_CACHE_PATTERNS: list[str] = [
     "claude-3.7-sonnet*",
     "claude-sonnet-3-7-latest",
     "claude-3-5-sonnet*",
+    "claude-3.5-sonnet*",
     "claude-3-5-haiku*",
     "claude-3.5-haiku*",
     "claude-3-haiku-20240307*",


### PR DESCRIPTION
Tiny fix for tool use enabled by default, ported from V0.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:154d857-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-154d857-python \
  ghcr.io/all-hands-ai/agent-server:154d857-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:154d857-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:154d857-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:154d857-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `154d857` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->