### PR TITLE
Add conversation_id support to agent_server and RemoteConversation

### DIFF
--- a/openhands/agent_server/conversation_router.py
+++ b/openhands/agent_server/conversation_router.py
@@ -3,7 +3,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Body, HTTPException, Query, status
+from fastapi import APIRouter, Body, HTTPException, Query, Response, status
 from pydantic import SecretStr
 
 from openhands.agent_server.config import get_default_config
@@ -134,9 +134,12 @@ async def start_conversation(
     request: Annotated[
         StartConversationRequest, Body(examples=START_CONVERSATION_EXAMPLES)
     ],
+    response: Response,
 ) -> ConversationInfo:
     """Start a conversation in the local environment."""
-    info = await conversation_service.start_conversation(request)
+    info, is_new = await conversation_service.start_conversation(request)
+    # Set appropriate status code: 201 for new conversations, 200 for existing ones
+    response.status_code = status.HTTP_201_CREATED if is_new else status.HTTP_200_OK
     return info
 
 

--- a/openhands/agent_server/models.py
+++ b/openhands/agent_server/models.py
@@ -54,6 +54,12 @@ class StartConversationRequest(BaseModel):
     """
 
     agent: AgentBase
+    conversation_id: UUID | None = Field(
+        default=None,
+        description="Optional conversation ID. If provided and the conversation "
+        "already exists, returns the existing conversation. If not provided, "
+        "a new UUID will be generated.",
+    )
     confirmation_policy: ConfirmationPolicyBase = Field(
         default=NeverConfirm(),
         description="Controls when the conversation will prompt the user before "

--- a/tests/agent_server/test_conversation_router_conversation_id.py
+++ b/tests/agent_server/test_conversation_router_conversation_id.py
@@ -1,0 +1,120 @@
+"""Tests for conversation router with conversation_id functionality."""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
+from openhands.agent_server.models import ConversationInfo
+from openhands.sdk import LLM, Agent
+from openhands.sdk.conversation.state import AgentExecutionStatus
+from openhands.sdk.security.confirmation_policy import NeverConfirm
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI app without authentication."""
+    config = Config(session_api_keys=[])  # Disable authentication
+    return TestClient(create_app(config))
+
+
+@pytest.fixture
+def sample_agent():
+    """Create a sample agent for testing."""
+    return Agent(
+        llm=LLM(model="gpt-4", service_id="test-llm"),
+        tools=[],
+    )
+
+
+class TestConversationRouterConversationId:
+    """Test cases for conversation router with conversation_id functionality."""
+
+    @patch("openhands.agent_server.conversation_router.conversation_service")
+    def test_start_conversation_new_returns_201(
+        self, mock_service, client, sample_agent
+    ):
+        """Test that starting a new conversation returns 201 status."""
+        conversation_id = uuid4()
+
+        # Mock the service to return a new conversation
+        mock_conversation_info = ConversationInfo(
+            id=conversation_id,
+            agent=sample_agent,
+            agent_status=AgentExecutionStatus.IDLE,
+            confirmation_policy=NeverConfirm(),
+        )
+        mock_service.start_conversation = AsyncMock(
+            return_value=(mock_conversation_info, True)
+        )
+
+        # Create request payload
+        payload = {
+            "agent": sample_agent.model_dump(),
+            "conversation_id": str(conversation_id),
+        }
+
+        response = client.post("/api/conversations/", json=payload)
+
+        assert response.status_code == 201
+        assert response.json()["id"] == str(conversation_id)
+
+    @patch("openhands.agent_server.conversation_router.conversation_service")
+    def test_start_conversation_existing_returns_200(
+        self, mock_service, client, sample_agent
+    ):
+        """Test that starting an existing conversation returns 200 status."""
+        conversation_id = uuid4()
+
+        # Mock the service to return an existing conversation
+        mock_conversation_info = ConversationInfo(
+            id=conversation_id,
+            agent=sample_agent,
+            agent_status=AgentExecutionStatus.IDLE,
+            confirmation_policy=NeverConfirm(),
+        )
+        mock_service.start_conversation = AsyncMock(
+            return_value=(mock_conversation_info, False)
+        )
+
+        # Create request payload
+        payload = {
+            "agent": sample_agent.model_dump(),
+            "conversation_id": str(conversation_id),
+        }
+
+        response = client.post("/api/conversations/", json=payload)
+
+        assert response.status_code == 200
+        assert response.json()["id"] == str(conversation_id)
+
+    @patch("openhands.agent_server.conversation_router.conversation_service")
+    def test_start_conversation_without_id_returns_201(
+        self, mock_service, client, sample_agent
+    ):
+        """Test that starting a conversation without ID returns 201 status."""
+        conversation_id = uuid4()
+
+        # Mock the service to return a new conversation
+        mock_conversation_info = ConversationInfo(
+            id=conversation_id,
+            agent=sample_agent,
+            agent_status=AgentExecutionStatus.IDLE,
+            confirmation_policy=NeverConfirm(),
+        )
+        mock_service.start_conversation = AsyncMock(
+            return_value=(mock_conversation_info, True)
+        )
+
+        # Create request payload without conversation_id
+        payload = {
+            "agent": sample_agent.model_dump(),
+        }
+
+        response = client.post("/api/conversations/", json=payload)
+
+        assert response.status_code == 201
+        assert response.json()["id"] == str(conversation_id)


### PR DESCRIPTION
## Summary

This PR adds support for passing `conversation_id` in POST requests when creating conversations, allowing local conversation IDs to match remote conversation IDs.

## Changes Made

### Core Functionality
- **`models.py`**: Added optional `conversation_id: UUID | None` field to `StartConversationRequest` model
- **`conversation_service.py`**: Modified `start_conversation()` to:
  - Accept and use provided conversation_id or generate new one
  - Check for existing conversations and return them if found
  - Return tuple `(ConversationInfo, bool)` indicating if conversation is new
- **`conversation_router.py`**: Updated router to return appropriate HTTP status codes:
  - 201 for newly created conversations
  - 200 for existing conversations
- **`remote_conversation.py`**: Updated `RemoteConversation` to include `conversation_id` in POST payload when provided

### Testing
- Added comprehensive service tests covering new ID, existing ID, and auto-generated ID scenarios
- Added router tests to verify correct HTTP status codes (200 vs 201)
- All existing tests continue to pass

## Behavior

### New Conversation
```bash
POST /api/conversations/
{
  "agent": {...},
  "conversation_id": "550e8400-e29b-41d4-a716-446655440000"
}
# Returns 201 Created
```

### Existing Conversation
```bash
POST /api/conversations/
{
  "agent": {...},
  "conversation_id": "550e8400-e29b-41d4-a716-446655440000"  # Already exists
}
# Returns 200 OK with existing conversation
```

### Auto-generated ID (backward compatible)
```bash
POST /api/conversations/
{
  "agent": {...}
  # No conversation_id provided
}
# Returns 201 Created with new UUID
```

## Benefits

- Enables synchronization between client and server conversation management
- Maintains full backward compatibility
- Follows RESTful conventions with appropriate status codes
- Allows clients to resume existing conversations by ID

## Testing

All tests pass:
```bash
uv run pytest tests/agent_server/test_conversation_service.py::TestConversationServiceStartConversation -v
uv run pytest tests/agent_server/test_conversation_router_conversation_id.py -v
```

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/113456c6f716431888d1165e1eb50e14)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:3cf7b14-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3cf7b14-python \
  ghcr.io/all-hands-ai/agent-server:3cf7b14-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:3cf7b14-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:3cf7b14-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:3cf7b14-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `3cf7b14` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->