### PR TITLE
Remove load_from_toml function and tomli dependency

### DIFF
--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -832,21 +832,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 data[field_name] = v
         return cls(**data)
 
-    @classmethod
-    def load_from_toml(cls, toml_path: str) -> LLM:
-        try:
-            import tomllib
-        except ImportError:
-            try:
-                import tomli as tomllib  # type: ignore
-            except ImportError:
-                raise ImportError("tomllib or tomli is required to load TOML files")
-        with open(toml_path, "rb") as f:
-            data = tomllib.load(f)
-        if "llm" in data:
-            data = data["llm"]
-        return cls(**data)
-
     def resolve_diff_from_deserialized(self, persisted: LLM) -> LLM:
         """Resolve differences between a deserialized LLM and the current instance.
 

--- a/openhands/sdk/pyproject.toml
+++ b/openhands/sdk/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "python-frontmatter>=1.1.0",
     "python-json-logger>=3.3.0",
     "tenacity>=9.1.2",
-    "tomli>=1.2.0; python_version<'3.11'",
+
     "websockets>=12",
 ]
 

--- a/openhands/sdk/pyproject.toml
+++ b/openhands/sdk/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "python-frontmatter>=1.1.0",
     "python-json-logger>=3.3.0",
     "tenacity>=9.1.2",
-
     "websockets>=12",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1823,7 +1823,6 @@ requires-dist = [
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "tenacity", specifier = ">=9.1.2" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.2.0" },
     { name = "websockets", specifier = ">=12" },
 ]
 provides-extras = ["boto3"]


### PR DESCRIPTION
- Remove unused load_from_toml function from LLM class
- Remove tomli dependency from pyproject.toml since Python 3.12+ has built-in tomllib
- Function was not used anywhere in the codebase
- All tests pass after removal