### PR TITLE
feat: add customizable system prompt support to Agent class

### DIFF
--- a/tests/agent_server/test_system_prompt_integration.py
+++ b/tests/agent_server/test_system_prompt_integration.py
@@ -1,0 +1,114 @@
+"""Test system prompt integration with agent server."""
+
+import json
+
+from openhands.agent_server.models import StartConversationRequest
+from openhands.sdk import LLM, Agent
+from openhands.sdk.agent.base import AgentBase
+
+
+def test_start_conversation_request_with_custom_system_prompt():
+    """Test that StartConversationRequest properly handles custom system prompt."""
+    custom_prompt = "You are a helpful AI assistant specialized in code review."
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[], system_prompt=custom_prompt)
+
+    # Create StartConversationRequest
+    request = StartConversationRequest(agent=agent)
+
+    # Should include the agent with custom system prompt
+    assert request.agent.system_prompt == custom_prompt
+    assert request.agent.system_message == custom_prompt
+
+
+def test_start_conversation_request_serialization_with_system_prompt():
+    """Test that StartConversationRequest serializes custom system prompt correctly."""
+    custom_prompt = "You are a helpful AI assistant specialized in code review."
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[], system_prompt=custom_prompt)
+
+    # Create and serialize StartConversationRequest
+    request = StartConversationRequest(agent=agent)
+    request_dict = request.model_dump()
+
+    # Should include system_prompt in the agent data
+    assert "agent" in request_dict
+    assert "system_prompt" in request_dict["agent"]
+    assert request_dict["agent"]["system_prompt"] == custom_prompt
+
+
+def test_start_conversation_request_json_roundtrip_with_system_prompt():
+    """Test that StartConversationRequest survives JSON roundtrip with custom system prompt."""  # noqa: E501
+    custom_prompt = "You are a helpful AI assistant specialized in code review."
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[], system_prompt=custom_prompt)
+
+    # Create StartConversationRequest
+    request = StartConversationRequest(agent=agent)
+
+    # Serialize to JSON
+    request_json = request.model_dump_json()
+
+    # Deserialize from JSON
+    deserialized_request = StartConversationRequest.model_validate_json(request_json)
+
+    # Should preserve the custom system prompt
+    assert isinstance(deserialized_request.agent, Agent)
+    assert deserialized_request.agent.system_prompt == custom_prompt
+    assert deserialized_request.agent.system_message == custom_prompt
+
+
+def test_agent_serialization_in_conversation_payload():
+    """Test that agent serialization for conversation API includes system prompt."""
+    custom_prompt = "You are a helpful AI assistant specialized in code review."
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[], system_prompt=custom_prompt)
+
+    # Simulate the payload creation as done in RemoteConversation
+    payload = {
+        "agent": agent.model_dump(mode="json", context={"expose_secrets": True}),
+        "initial_message": None,
+        "max_iterations": 500,
+        "stuck_detection": True,
+    }
+
+    # Should include system_prompt in the agent data
+    assert "system_prompt" in payload["agent"]
+    assert payload["agent"]["system_prompt"] == custom_prompt
+
+    # Should be JSON serializable
+    json_payload = json.dumps(payload)
+    parsed_payload = json.loads(json_payload)
+
+    # Should preserve system_prompt after JSON roundtrip
+    assert parsed_payload["agent"]["system_prompt"] == custom_prompt
+
+    # Should be able to reconstruct the agent
+    reconstructed_agent = AgentBase.model_validate(parsed_payload["agent"])
+    assert isinstance(reconstructed_agent, Agent)
+    assert reconstructed_agent.system_prompt == custom_prompt
+    assert reconstructed_agent.system_message == custom_prompt
+
+
+def test_agent_without_custom_system_prompt_in_conversation():
+    """Test that agent without custom system prompt works correctly in conversation."""
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[])  # No custom system_prompt
+
+    # Create StartConversationRequest
+    request = StartConversationRequest(agent=agent)
+
+    # Should have None for system_prompt but valid system_message
+    assert request.agent.system_prompt is None
+    assert isinstance(request.agent.system_message, str)
+    assert len(request.agent.system_message) > 0
+
+    # Should serialize correctly
+    request_dict = request.model_dump()
+    assert request_dict["agent"]["system_prompt"] is None
+
+    # Should survive JSON roundtrip
+    request_json = request.model_dump_json()
+    deserialized_request = StartConversationRequest.model_validate_json(request_json)
+    assert deserialized_request.agent.system_prompt is None
+    assert isinstance(deserialized_request.agent.system_message, str)

--- a/tests/sdk/agent/test_system_prompt.py
+++ b/tests/sdk/agent/test_system_prompt.py
@@ -1,0 +1,134 @@
+"""Test system prompt customization functionality."""
+
+import json
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.agent.base import AgentBase
+from openhands.sdk.llm import LLM
+
+
+def test_agent_default_system_prompt():
+    """Test that agent uses template-based system prompt by default."""
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[])
+
+    # Should use template-based system message
+    system_message = agent.system_message
+    assert isinstance(system_message, str)
+    assert len(system_message) > 0
+    # Should contain content from the default template
+    assert "OpenHands agent" in system_message
+
+
+def test_agent_custom_system_prompt():
+    """Test that agent uses custom system prompt when provided."""
+    custom_prompt = "You are a helpful AI assistant specialized in code review."
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[], system_prompt=custom_prompt)
+
+    # Should use the custom system prompt
+    system_message = agent.system_message
+    assert system_message == custom_prompt
+
+
+def test_agent_custom_system_prompt_with_agent_context():
+    """Test that agent context suffix is applied to custom system prompt."""
+    from openhands.sdk.context.agent_context import AgentContext
+
+    custom_prompt = "You are a helpful AI assistant."
+    suffix = "Always end responses with 'Have a great day!'"
+
+    agent_context = AgentContext(system_message_suffix=suffix)
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(
+        llm=llm, tools=[], system_prompt=custom_prompt, agent_context=agent_context
+    )
+
+    # Should use custom prompt with context suffix
+    system_message = agent.system_message
+    assert system_message == f"{custom_prompt}\n\n{suffix}"
+
+
+def test_agent_system_prompt_serialization():
+    """Test that custom system prompt is included in model_dump."""
+    custom_prompt = "You are a helpful AI assistant specialized in code review."
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[], system_prompt=custom_prompt)
+
+    # Should include system_prompt in serialization
+    agent_dict = agent.model_dump()
+    assert "system_prompt" in agent_dict
+    assert agent_dict["system_prompt"] == custom_prompt
+
+
+def test_agent_system_prompt_json_serialization():
+    """Test that custom system prompt survives JSON serialization/deserialization."""
+    custom_prompt = "You are a helpful AI assistant specialized in code review."
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[], system_prompt=custom_prompt)
+
+    # Serialize to JSON
+    agent_json = agent.model_dump_json()
+
+    # Deserialize from JSON
+    deserialized_agent = AgentBase.model_validate_json(agent_json)
+
+    # Should preserve the custom system prompt
+    assert isinstance(deserialized_agent, Agent)
+    assert deserialized_agent.system_prompt == custom_prompt
+    assert deserialized_agent.system_message == custom_prompt
+
+
+def test_agent_system_prompt_none_serialization():
+    """Test that None system_prompt is handled correctly in serialization."""
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[], system_prompt=None)
+
+    # Should include system_prompt as None in serialization
+    agent_dict = agent.model_dump()
+    assert "system_prompt" in agent_dict
+    assert agent_dict["system_prompt"] is None
+
+    # Should use template-based system message
+    system_message = agent.system_message
+    assert isinstance(system_message, str)
+    assert len(system_message) > 0
+
+
+def test_agent_system_prompt_json_roundtrip():
+    """Test that system prompt survives JSON roundtrip with dict parsing."""
+    custom_prompt = "You are a helpful AI assistant specialized in code review."
+    llm = LLM(model="test-model", service_id="test-llm")
+    agent = Agent(llm=llm, tools=[], system_prompt=custom_prompt)
+
+    # Serialize to JSON, then parse to dict
+    agent_json = agent.model_dump_json()
+    agent_dict = json.loads(agent_json)
+
+    # Deserialize from dict
+    deserialized_agent = AgentBase.model_validate(agent_dict)
+
+    # Should preserve the custom system prompt
+    assert isinstance(deserialized_agent, Agent)
+    assert deserialized_agent.system_prompt == custom_prompt
+    assert deserialized_agent.system_message == custom_prompt
+
+
+def test_agent_system_prompt_overrides_template():
+    """Test that custom system prompt completely overrides template-based generation."""
+    custom_prompt = "Custom prompt without any template content."
+    llm = LLM(model="test-model", service_id="test-llm")
+
+    # Create agent with custom system prompt and template kwargs
+    agent = Agent(
+        llm=llm,
+        tools=[],
+        system_prompt=custom_prompt,
+        system_prompt_kwargs={"cli_mode": True},  # This should be ignored
+    )
+
+    # Should use only the custom prompt, ignoring template kwargs
+    system_message = agent.system_message
+    assert system_message == custom_prompt
+    # Should not contain any template content
+    assert "OpenHands agent" not in system_message


### PR DESCRIPTION
## Summary

This PR adds support for customizable system prompts in the Agent class, enabling users to override the default template-based system message with their own custom prompts. The feature is designed to be fully backward compatible while providing seamless integration with the RemoteConversation API and agent_server.

## Changes Made

### Core Implementation
- **Added `system_prompt` field** to `AgentBase` with optional string type and comprehensive Field documentation
- **Updated `system_message` property** to prioritize custom system prompt over template-based generation
- **Maintained backward compatibility** - existing agents continue to work without any changes

### API Integration
- **Automatic serialization** - `system_prompt` is included in `model_dump()` via Pydantic BaseModel inheritance
- **RemoteConversation support** - custom system prompts are automatically transmitted to remote agents
- **agent_server compatibility** - server can accept and process system prompts in request bodies

### Testing
- **8 comprehensive unit tests** covering system prompt functionality
- **5 integration tests** verifying agent_server compatibility
- **All existing tests pass** - no regressions introduced

## Usage Examples

### Basic Usage
```python
from openhands.sdk.agent import Agent
from openhands.sdk.llm import LLM

# Create agent with custom system prompt
llm = LLM(model="gpt-4o-mini", service_id="openai")
agent = Agent(
    llm=llm,
    tools=[],
    system_prompt="You are a helpful AI assistant specialized in code review."
)
```

### With RemoteConversation
```python
from openhands.sdk.conversation.impl.remote_conversation import RemoteConversation

# Custom system prompt is automatically included in serialization
conversation = RemoteConversation(agent=agent)
# The remote agent will receive and use the custom system prompt
```

### agent_server Integration
```python
# StartConversationRequest automatically includes system_prompt
request = StartConversationRequest(agent=agent)
# Server processes the custom system prompt from the request body
```

## Technical Details

### Implementation Approach
- **Field-based customization**: Uses Pydantic field with optional type for clean API
- **Property-based logic**: `system_message` property handles the fallback logic transparently
- **Zero-overhead**: No performance impact when using default behavior
- **Type-safe**: Full type checking support with proper annotations

### Backward Compatibility
- **Existing code unchanged**: All current Agent instantiations work without modification
- **Template system preserved**: Default behavior continues to use the existing template system
- **API consistency**: No breaking changes to existing methods or properties

### Serialization Behavior
- **Automatic inclusion**: `system_prompt` field is automatically included in `model_dump()`
- **JSON roundtrip safe**: Supports full serialization/deserialization cycles
- **Remote API ready**: Works seamlessly with RemoteConversation and agent_server

## Testing Coverage

### Unit Tests (`tests/sdk/agent/test_system_prompt.py`)
- Default system prompt behavior
- Custom system prompt functionality  
- System prompt with agent context
- Serialization and JSON roundtrip tests
- Template override verification

### Integration Tests (`tests/agent_server/test_system_prompt_integration.py`)
- StartConversationRequest with custom system prompts
- Serialization compatibility with agent_server
- JSON roundtrip testing for server payloads
- Agent serialization in conversation payloads

## Validation

- ✅ All 39 existing agent tests pass
- ✅ All 13 new tests pass (8 unit + 5 integration)
- ✅ Pre-commit hooks pass (formatting, linting, type checking)
- ✅ No breaking changes to existing functionality
- ✅ Full backward compatibility maintained

## Related Issues

This PR addresses the need for customizable system prompts as requested in the user context, enabling:
- Easy system prompt customization in Agent class
- Automatic inclusion in model_dump for RemoteConversation API  
- Support for system prompt in agent_server request bodies

The implementation follows the repository's engineering principles of simplicity, backward compatibility, and maintainable architecture.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3cf9d29725be461989d85b75fb95d374)