### PR TITLE
Refactor tool validation in agent.py step() method

### DIFF
--- a/tests/sdk/agent/test_agent_tool_validation.py
+++ b/tests/sdk/agent/test_agent_tool_validation.py
@@ -1,0 +1,175 @@
+"""Test the refactored tool validation logic in agent.py."""
+
+import json
+
+from litellm.types.utils import ChatCompletionMessageToolCall, Function
+from pydantic import SecretStr
+
+from openhands.sdk import Conversation
+from openhands.sdk.agent.agent import Agent
+from openhands.sdk.event import AgentErrorEvent
+from openhands.sdk.llm import LLM
+
+
+def test_validate_tool_call_non_function_type():
+    """Test that _validate_tool_call returns error for non-function tool calls."""
+    agent = Agent(
+        llm=LLM(
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
+        )
+    )
+
+    # Create a tool call with non-function type
+    tool_call = ChatCompletionMessageToolCall(
+        id="test-id",
+        type="not_function",  # Invalid type
+        function=Function(name="test_tool", arguments="{}"),
+    )
+
+    error = agent._validate_tool_call(tool_call)
+    assert error is not None
+    assert isinstance(error, AgentErrorEvent)
+    assert "not of type 'function'" in error.error
+    assert error.tool_name == "test_tool"
+    assert error.tool_call_id == "test-id"
+
+
+def test_validate_tool_call_missing_tool_name():
+    """Test that _validate_tool_call returns error for tool calls without name."""
+    agent = Agent(
+        llm=LLM(
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
+        )
+    )
+
+    # Create a tool call with no function name
+    tool_call = ChatCompletionMessageToolCall(
+        id="test-id",
+        type="function",
+        function=Function(name=None, arguments="{}"),
+    )
+
+    error = agent._validate_tool_call(tool_call)
+    assert error is not None
+    assert isinstance(error, AgentErrorEvent)
+    assert "Tool call must have a name" in error.error
+    assert error.tool_name == "unknown"
+    assert error.tool_call_id == "test-id"
+
+
+def test_validate_tool_call_tool_not_found():
+    """Test that _validate_tool_call returns error for non-existent tools."""
+    agent = Agent(
+        llm=LLM(
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
+        )
+    )
+    # Initialize the agent by creating a conversation
+    Conversation(agent=agent, visualize=False)
+
+    # Create a tool call for a tool that doesn't exist
+    tool_call = ChatCompletionMessageToolCall(
+        id="test-id",
+        type="function",
+        function=Function(name="nonexistent_tool", arguments="{}"),
+    )
+
+    error = agent._validate_tool_call(tool_call)
+    assert error is not None
+    assert isinstance(error, AgentErrorEvent)
+    assert "Tool 'nonexistent_tool' not found" in error.error
+    assert error.tool_name == "nonexistent_tool"
+    assert error.tool_call_id == "test-id"
+
+
+def test_validate_tool_call_invalid_arguments():
+    """Test that _validate_tool_call returns error for invalid arguments."""
+    agent = Agent(
+        llm=LLM(
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
+        )
+    )
+    # Initialize the agent by creating a conversation
+    Conversation(agent=agent, visualize=False)
+
+    # Create a tool call with invalid JSON arguments
+    tool_call = ChatCompletionMessageToolCall(
+        id="test-id",
+        type="function",
+        function=Function(name="finish", arguments="invalid json"),
+    )
+
+    error = agent._validate_tool_call(tool_call)
+    assert error is not None
+    assert isinstance(error, AgentErrorEvent)
+    assert "Error validating args" in error.error
+    assert error.tool_name == "finish"
+    assert error.tool_call_id == "test-id"
+
+
+def test_validate_tool_call_valid_tool():
+    """Test that _validate_tool_call returns None for valid tool calls."""
+    agent = Agent(
+        llm=LLM(
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
+        )
+    )
+    # Initialize the agent by creating a conversation
+    Conversation(agent=agent, visualize=False)
+
+    # Create a valid tool call for the finish tool
+    tool_call = ChatCompletionMessageToolCall(
+        id="test-id",
+        type="function",
+        function=Function(
+            name="finish",
+            arguments=json.dumps({"message": "Task completed successfully"}),
+        ),
+    )
+
+    error = agent._validate_tool_call(tool_call)
+    assert error is None
+
+
+def test_validate_tool_call_with_security_risk():
+    """Test that _validate_tool_call handles security_risk field correctly."""
+    agent = Agent(
+        llm=LLM(
+            service_id="test-llm",
+            model="test-model",
+            api_key=SecretStr("test-key"),
+            base_url="http://test",
+        )
+    )
+    # Initialize the agent by creating a conversation
+    Conversation(agent=agent, visualize=False)
+
+    # Create a valid tool call with security_risk field
+    tool_call = ChatCompletionMessageToolCall(
+        id="test-id",
+        type="function",
+        function=Function(
+            name="finish",
+            arguments=json.dumps(
+                {"message": "Task completed successfully", "security_risk": "LOW"}
+            ),
+        ),
+    )
+
+    error = agent._validate_tool_call(tool_call)
+    assert error is None  # Should pass validation even with security_risk field


### PR DESCRIPTION
## Summary

This PR refactors the `step()` method in `agent.py` to improve code organization and readability by extracting tool validation logic into separate helper methods.

## Changes Made

### 1. Refactored `step()` method structure
- **Swapped if/else order** to use early return pattern for empty tool calls
- **Reduced nesting** by eliminating long conditional blocks
- **Simplified main logic** to focus on high-level flow

### 2. Created `_validate_tool_call()` helper method
- **Extracted all validation logic** from the main step method
- **Centralized error handling** for tool call validation
- **Returns `AgentErrorEvent | None`** for clear error indication
- **Handles all validation cases**:
  - Non-function type tool calls
  - Missing tool names
  - Tool not found errors
  - Invalid JSON arguments
  - Tool validation failures

### 3. Updated `_get_action_event()` method
- **Removed validation logic** (now handled by `_validate_tool_call`)
- **Focused solely on action event creation**
- **Cleaner separation of concerns**

### 4. Comprehensive test coverage
- **Added 6 new test cases** covering all validation scenarios
- **Tests for non-function tool calls**
- **Tests for missing tool names**
- **Tests for non-existent tools**
- **Tests for invalid arguments**
- **Tests for valid tool calls**
- **Tests for security_risk field handling**

## Benefits

- **Improved readability**: Shorter, more focused methods
- **Better maintainability**: Clear separation of validation and action creation
- **Enhanced testability**: Validation logic can be tested independently
- **Reduced complexity**: Early returns eliminate deep nesting
- **Backward compatibility**: All existing functionality preserved

## Testing

- ✅ All existing tests pass (37/37)
- ✅ New validation tests pass (6/6)
- ✅ Pre-commit hooks pass (formatting, linting, type checking)
- ✅ No breaking changes to existing API

## Code Quality

- Follows repository coding standards
- Maintains type safety with proper annotations
- Uses early return pattern to reduce complexity
- Clear method naming and documentation

Fixes #551

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3a1d467c7045456e8c70577efcfef0ee)