### PR TITLE
Add Anthropic thinking blocks support to events system

### DIFF
--- a/examples/25_anthropic_thinking.py
+++ b/examples/25_anthropic_thinking.py
@@ -1,0 +1,147 @@
+"""Example demonstrating Anthropic's extended thinking feature with thinking blocks.
+
+This example shows how to use Anthropic's extended thinking feature which provides
+thinking blocks that contain the model's internal reasoning process. These blocks
+are preserved and can be passed back to the API for tool use scenarios.
+"""
+
+import os
+
+from pydantic import SecretStr
+
+from openhands.sdk import (
+    LLM,
+    Agent,
+    Conversation,
+    EventBase,
+    LLMConvertibleEvent,
+    get_logger,
+)
+from openhands.sdk.tool import ToolSpec, register_tool
+from openhands.tools.execute_bash import BashTool
+
+
+logger = get_logger(__name__)
+
+# Configure LLM for Anthropic Claude with extended thinking
+api_key = os.getenv("LITELLM_API_KEY")
+assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+
+llm = LLM(
+    service_id="agent",
+    model="litellm_proxy/anthropic/claude-sonnet-4-5",
+    base_url="https://llm-proxy.eval.all-hands.dev",
+    api_key=SecretStr(api_key),
+    # Enable extended thinking with reasoning effort
+    reasoning_effort="low",  # Can be "low", "medium", or "high"
+)
+
+# Tools
+cwd = os.getcwd()
+register_tool("BashTool", BashTool)
+tools = [
+    ToolSpec(
+        name="BashTool",
+        params={"no_change_timeout_seconds": 3},
+    )
+]
+
+# Agent
+agent = Agent(llm=llm, tools=tools)
+
+llm_messages = []  # collect raw LLM messages
+
+
+def conversation_callback(event: EventBase):
+    """Callback to collect LLM messages and display thinking blocks."""
+    if isinstance(event, LLMConvertibleEvent):
+        message = event.to_llm_message()
+        llm_messages.append(message)
+
+        # Display thinking blocks if present
+        if hasattr(message, "thinking_blocks") and message.thinking_blocks:
+            print(
+                f"\n🧠 Thinking Blocks Found ({len(message.thinking_blocks)} blocks):"
+            )
+            for i, block in enumerate(message.thinking_blocks):
+                print(f"  Block {i + 1}:")
+                print(f"    Type: {block.type}")
+                print(f"    Thinking: {block.thinking[:200]}...")
+                if len(block.thinking) > 200:
+                    print("    [truncated]")
+                if block.signature:
+                    print(f"    Signature: {block.signature[:50]}...")
+                print()
+
+        # Also check if the event itself has thinking blocks (for MessageEvent)
+        if hasattr(event, "thinking_blocks"):
+            thinking_blocks = getattr(event, "thinking_blocks", [])
+            if thinking_blocks:
+                print(
+                    f"\n🧠 Event Thinking Blocks Found ({len(thinking_blocks)} blocks):"
+                )
+                for i, block in enumerate(thinking_blocks):
+                    print(f"  Block {i + 1}:")
+                    print(f"    Type: {block.type}")
+                    print(f"    Thinking: {block.thinking[:200]}...")
+                    if len(block.thinking) > 200:
+                        print("    [truncated]")
+                    if block.signature:
+                        print(f"    Signature: {block.signature[:50]}...")
+                    print()
+
+
+conversation = Conversation(
+    agent=agent, callbacks=[conversation_callback], workspace=cwd
+)
+
+print("🚀 Starting conversation with Anthropic Claude using extended thinking...")
+print("This will demonstrate thinking blocks in action.\n")
+
+# Send a complex reasoning task that will trigger extended thinking
+conversation.send_message(
+    "I need you to solve this step by step: Calculate the compound interest "
+    "for an investment of $10,000 at 5% annual interest rate compounded "
+    "quarterly for 3 years. Show your reasoning process and then use bash "
+    "to verify the calculation with a simple script."
+)
+
+conversation.run()
+
+print("\n" + "=" * 80)
+print("🎯 Conversation finished. Summary of LLM messages:")
+print("=" * 80)
+
+for i, message in enumerate(llm_messages):
+    print(f"\nMessage {i + 1}:")
+    print(f"  Role: {message.role}")
+    print(f"  Content items: {len(message.content)}")
+    print(f"  Thinking blocks: {len(message.thinking_blocks)}")
+    print(f"  Reasoning content: {'Yes' if message.reasoning_content else 'No'}")
+
+    # Show thinking block details
+    if message.thinking_blocks:
+        print("  Thinking block details:")
+        for j, block in enumerate(message.thinking_blocks):
+            print(f"    Block {j + 1}: {len(block.thinking)} chars")
+
+    # Show content preview
+    content_preview = str(message)[:150]
+    print(f"  Preview: {content_preview}...")
+
+print(f"\n📊 Total messages: {len(llm_messages)}")
+thinking_messages = [m for m in llm_messages if m.thinking_blocks]
+print(f"📊 Messages with thinking blocks: {len(thinking_messages)}")
+
+if thinking_messages:
+    total_thinking_blocks = sum(len(m.thinking_blocks) for m in thinking_messages)
+    print(f"📊 Total thinking blocks: {total_thinking_blocks}")
+
+    print("\n🧠 Thinking blocks successfully captured and preserved!")
+    print("These blocks can be passed back to the API for tool use scenarios.")
+else:
+    print("\n⚠️  No thinking blocks were captured.")
+    print("This might be because:")
+    print("  - The model didn't use extended thinking for this query")
+    print("  - The reasoning_effort was too low")
+    print("  - The API response format was different than expected")

--- a/openhands/sdk/llm/__init__.py
+++ b/openhands/sdk/llm/__init__.py
@@ -1,7 +1,13 @@
 from openhands.sdk.llm.llm import LLM
 from openhands.sdk.llm.llm_registry import LLMRegistry, RegistryEvent
 from openhands.sdk.llm.llm_response import LLMResponse
-from openhands.sdk.llm.message import ImageContent, Message, TextContent, content_to_str
+from openhands.sdk.llm.message import (
+    ImageContent,
+    Message,
+    TextContent,
+    ThinkingBlock,
+    content_to_str,
+)
 from openhands.sdk.llm.router import RouterLLM
 from openhands.sdk.llm.utils.metrics import Metrics, MetricsSnapshot
 from openhands.sdk.llm.utils.unverified_models import (
@@ -20,6 +26,7 @@ __all__ = [
     "Message",
     "TextContent",
     "ImageContent",
+    "ThinkingBlock",
     "content_to_str",
     "Metrics",
     "MetricsSnapshot",

--- a/tests/sdk/llm/test_thinking_blocks.py
+++ b/tests/sdk/llm/test_thinking_blocks.py
@@ -1,0 +1,317 @@
+"""Tests for Anthropic thinking blocks support in LLM and Message classes."""
+
+from litellm.types.llms.openai import ChatCompletionThinkingBlock
+from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelResponse, Usage
+
+
+def create_mock_response_with_thinking(
+    content: str = "Test response",
+    thinking_content: str = "Let me think about this...",
+    response_id: str = "test-id",
+):
+    """Helper function to create mock responses with thinking blocks."""
+    # Create a thinking block
+    thinking_block = ChatCompletionThinkingBlock(
+        type="thinking",
+        thinking=thinking_content,
+    )
+
+    # Create the message with thinking blocks
+    message = LiteLLMMessage(
+        content=content,
+        role="assistant",
+        thinking_blocks=[thinking_block],
+    )
+
+    return ModelResponse(
+        id=response_id,
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=message,
+            )
+        ],
+        created=1234567890,
+        model="claude-sonnet-4-5",
+        object="chat.completion",
+        usage=Usage(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+        ),
+    )
+
+
+def test_thinking_block_model():
+    """Test ThinkingBlock model creation and validation."""
+    from openhands.sdk.llm.message import ThinkingBlock
+
+    # Test basic thinking block
+    block = ThinkingBlock(
+        thinking="Let me think about this step by step...",
+    )
+
+    assert block.type == "thinking"
+    assert block.thinking == "Let me think about this step by step..."
+    assert block.signature is None
+
+    # Test thinking block with signature
+    block_with_sig = ThinkingBlock(
+        thinking="Complex reasoning process...",
+        signature="signature_hash_123",
+    )
+
+    assert block_with_sig.type == "thinking"
+    assert block_with_sig.thinking == "Complex reasoning process..."
+    assert block_with_sig.signature == "signature_hash_123"
+
+
+def test_message_with_thinking_blocks():
+    """Test Message with thinking blocks fields."""
+    from openhands.sdk.llm.message import Message, TextContent, ThinkingBlock
+
+    thinking_block = ThinkingBlock(
+        thinking="Let me think about this step by step...",
+        signature="sig123",
+    )
+
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="The answer is 42.")],
+        thinking_blocks=[thinking_block],
+    )
+
+    assert len(message.thinking_blocks) == 1
+    assert (
+        message.thinking_blocks[0].thinking == "Let me think about this step by step..."
+    )
+    assert message.thinking_blocks[0].signature == "sig123"
+
+
+def test_message_without_thinking_blocks():
+    """Test Message without thinking blocks (default behavior)."""
+    from openhands.sdk.llm.message import Message, TextContent
+
+    message = Message(role="assistant", content=[TextContent(text="The answer is 42.")])
+
+    assert message.thinking_blocks == []
+
+
+def test_message_from_litellm_message_with_thinking():
+    """Test Message.from_litellm_message with thinking blocks."""
+    from openhands.sdk.llm.message import Message
+
+    # Create a mock LiteLLM message with thinking blocks
+    thinking_block = ChatCompletionThinkingBlock(
+        type="thinking",
+        thinking="Let me analyze this problem...",
+        signature="hash_456",
+    )
+
+    litellm_message = LiteLLMMessage(
+        role="assistant",
+        content="The answer is 42.",
+        thinking_blocks=[thinking_block],
+    )
+
+    message = Message.from_litellm_message(litellm_message)
+
+    assert message.role == "assistant"
+    assert len(message.content) == 1
+    from openhands.sdk.llm.message import TextContent
+
+    assert isinstance(message.content[0], TextContent)
+    assert message.content[0].text == "The answer is 42."
+
+    # Check thinking blocks
+    assert len(message.thinking_blocks) == 1
+    assert message.thinking_blocks[0].thinking == "Let me analyze this problem..."
+    assert message.thinking_blocks[0].signature == "hash_456"
+
+
+def test_message_from_litellm_message_without_thinking():
+    """Test Message.from_litellm_message without thinking blocks."""
+    from openhands.sdk.llm.message import Message
+
+    litellm_message = LiteLLMMessage(role="assistant", content="The answer is 42.")
+
+    message = Message.from_litellm_message(litellm_message)
+
+    assert message.role == "assistant"
+    assert len(message.content) == 1
+    from openhands.sdk.llm.message import TextContent
+
+    assert isinstance(message.content[0], TextContent)
+    assert message.content[0].text == "The answer is 42."
+    assert message.thinking_blocks == []
+
+
+def test_message_serialization_with_thinking_blocks():
+    """Test Message serialization includes thinking blocks."""
+    from openhands.sdk.llm.message import Message, TextContent, ThinkingBlock
+
+    thinking_block = ThinkingBlock(
+        thinking="Reasoning process...",
+        signature="sig789",
+    )
+
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="Answer")],
+        thinking_blocks=[thinking_block],
+    )
+
+    serialized = message.model_dump()
+
+    assert len(serialized["thinking_blocks"]) == 1
+    assert serialized["thinking_blocks"][0]["thinking"] == "Reasoning process..."
+    assert serialized["thinking_blocks"][0]["signature"] == "sig789"
+    assert serialized["thinking_blocks"][0]["type"] == "thinking"
+
+
+def test_message_serialization_without_thinking_blocks():
+    """Test Message serialization without thinking blocks."""
+    from openhands.sdk.llm.message import Message, TextContent
+
+    message = Message(role="assistant", content=[TextContent(text="Answer")])
+
+    serialized = message.model_dump()
+
+    assert serialized["thinking_blocks"] == []
+
+
+def test_message_list_serializer_with_thinking_blocks():
+    """Test Message._list_serializer includes thinking blocks in content array."""
+    from openhands.sdk.llm.message import Message, TextContent, ThinkingBlock
+
+    thinking_block = ThinkingBlock(
+        thinking="Let me think...",
+        signature="sig_abc",
+    )
+
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="The answer is 42.")],
+        thinking_blocks=[thinking_block],
+    )
+
+    serialized = message._list_serializer()
+    content_list = serialized["content"]
+
+    # Should have thinking block first, then text content
+    assert len(content_list) == 2
+    assert content_list[0]["type"] == "thinking"
+    assert content_list[0]["thinking"] == "Let me think..."
+    assert content_list[0]["signature"] == "sig_abc"
+    assert content_list[1]["type"] == "text"
+    assert content_list[1]["text"] == "The answer is 42."
+
+
+def test_message_event_thinking_blocks_property():
+    """Test MessageEvent thinking_blocks property."""
+    from openhands.sdk.event.llm_convertible import MessageEvent
+    from openhands.sdk.llm.message import Message, TextContent, ThinkingBlock
+
+    thinking_block = ThinkingBlock(
+        thinking="Complex reasoning...",
+        signature="sig_def",
+    )
+
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="Result")],
+        thinking_blocks=[thinking_block],
+    )
+
+    event = MessageEvent(llm_message=message, source="agent")
+
+    # Test thinking_blocks property
+    assert len(event.thinking_blocks) == 1
+    assert event.thinking_blocks[0].thinking == "Complex reasoning..."
+    assert event.thinking_blocks[0].signature == "sig_def"
+
+
+def test_message_event_visualize_with_thinking_blocks():
+    """Test MessageEvent.visualize includes thinking blocks."""
+    from openhands.sdk.event.llm_convertible import MessageEvent
+    from openhands.sdk.llm.message import Message, TextContent, ThinkingBlock
+
+    thinking_block = ThinkingBlock(
+        thinking=(
+            "This is a very long thinking process that should be truncated when "
+            "displayed in the visualization because it exceeds the 200 character "
+            "limit that we set for the preview display."
+        ),
+        signature="sig_ghi",
+    )
+
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="Final answer")],
+        thinking_blocks=[thinking_block],
+    )
+
+    event = MessageEvent(llm_message=message, source="agent")
+
+    visualization = event.visualize
+
+    # Should contain thinking blocks section
+    viz_text = str(visualization)
+    assert "Thinking Blocks (Anthropic Extended Thinking)" in viz_text
+    assert "Block 1:" in viz_text
+    assert "..." in viz_text  # Long thinking should be truncated
+
+
+def test_message_event_str_with_thinking_blocks():
+    """Test MessageEvent.__str__ includes thinking blocks count."""
+    from openhands.sdk.event.llm_convertible import MessageEvent
+    from openhands.sdk.llm.message import Message, TextContent, ThinkingBlock
+
+    thinking_blocks = [
+        ThinkingBlock(thinking="First thought"),
+        ThinkingBlock(thinking="Second thought"),
+    ]
+
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="Answer")],
+        thinking_blocks=thinking_blocks,
+    )
+
+    event = MessageEvent(llm_message=message, source="agent")
+
+    str_repr = str(event)
+
+    # Should include thinking blocks count
+    assert "[Thinking blocks: 2]" in str_repr
+
+
+def test_multiple_thinking_blocks():
+    """Test handling multiple thinking blocks."""
+    from openhands.sdk.llm.message import Message, TextContent, ThinkingBlock
+
+    thinking_blocks = [
+        ThinkingBlock(thinking="First reasoning step", signature="sig1"),
+        ThinkingBlock(thinking="Second reasoning step", signature="sig2"),
+        ThinkingBlock(thinking="Final reasoning step"),
+    ]
+
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="Conclusion")],
+        thinking_blocks=thinking_blocks,
+    )
+
+    assert len(message.thinking_blocks) == 3
+    assert message.thinking_blocks[0].thinking == "First reasoning step"
+    assert message.thinking_blocks[1].thinking == "Second reasoning step"
+    assert message.thinking_blocks[2].thinking == "Final reasoning step"
+    assert message.thinking_blocks[2].signature is None
+
+    # Test serialization
+    serialized = message._list_serializer()
+    content_list = serialized["content"]
+    assert len(content_list) == 4  # 3 thinking blocks + 1 text content
+    assert all(item["type"] == "thinking" for item in content_list[:3])
+    assert content_list[3]["type"] == "text"


### PR DESCRIPTION
## Summary

This PR implements Anthropic's thinking blocks feature in the OpenHands SDK events system, enabling support for extended thinking capabilities as described in the [LiteLLM documentation](https://docs.litellm.ai/docs/reasoning_content#pass-thinking-to-anthropic-models).

## Changes Made

### Core Implementation
- **Added `ThinkingBlock` model**: New Pydantic model for Anthropic thinking blocks with `type`, `thinking`, and `signature` fields
- **Enhanced `Message` class**: Added `thinking_blocks` field with default empty list
- **Updated `from_litellm_message()`**: Extract thinking blocks from LiteLLM responses using dict access for TypedDict compatibility
- **Added `thinking_blocks` property**: New property in `MessageEvent` class to access thinking blocks

### Visualization & Display
- **Enhanced `MessageEvent.visualize`**: Display thinking blocks with truncation for better readability
- **Updated `MessageEvent.__str__()`**: Include thinking block count in string representation
- **Added thinking block serialization**: Thinking blocks are included in message serialization for API compatibility

### Testing & Examples
- **Comprehensive test suite**: 12 unit tests covering all functionality in `tests/sdk/llm/test_thinking_blocks.py`
- **Updated example script**: Enhanced `examples/25_anthropic_thinking.py` with proper callback handling
- **Export support**: Added `ThinkingBlock` to `openhands.sdk.llm` module exports

## Technical Details

### Anthropic Thinking Blocks Format
According to the LiteLLM docs, Anthropic thinking blocks are not normalized and have a specific format:
```python
{
    "type": "thinking",
    "thinking": "The model's internal reasoning...",
    "signature": "unique_identifier"
}
```

### Implementation Approach
- **Non-intrusive**: Thinking blocks are optional and default to empty list
- **Backward compatible**: Existing code continues to work without changes
- **Type safe**: Full type annotations and Pydantic validation
- **Efficient**: Uses dict access to avoid TypedDict compatibility issues

### Usage Example
```python
# Thinking blocks are automatically extracted from LiteLLM responses
message = Message.from_litellm_message(litellm_response)
if message.thinking_blocks:
    for block in message.thinking_blocks:
        print(f"Thinking: {block.thinking}")
        print(f"Signature: {block.signature}")
```

## Testing

- ✅ All 12 unit tests pass
- ✅ Pre-commit hooks pass (formatting, linting, type checking)
- ✅ Mock data testing confirms correct functionality
- ✅ Backward compatibility verified

## Notes

- The LiteLLM proxy may not yet support the `reasoning_effort` parameter for Anthropic models
- Thinking blocks are preserved in their raw format as per Anthropic's requirements
- This feature is specific to Anthropic models and complements the existing `reasoning_content` field

Fixes #172

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9d3a992c42974edabfeb9cb4e5fa4e42)