### PR TITLE
Have post to /conversations work without redirect

### DIFF
--- a/openhands/agent_server/conversation_router.py
+++ b/openhands/agent_server/conversation_router.py
@@ -105,7 +105,7 @@ async def get_conversation(conversation_id: UUID) -> ConversationInfo:
     return conversation
 
 
-@conversation_router.get("/")
+@conversation_router.get("")
 async def batch_get_conversations(
     ids: Annotated[list[UUID], Query()],
 ) -> list[ConversationInfo | None]:
@@ -119,7 +119,7 @@ async def batch_get_conversations(
 # Write Methods
 
 
-@conversation_router.post("/")
+@conversation_router.post("")
 async def start_conversation(
     request: Annotated[
         StartConversationRequest, Body(examples=START_CONVERSATION_EXAMPLES)

--- a/openhands/agent_server/event_router.py
+++ b/openhands/agent_server/event_router.py
@@ -97,7 +97,7 @@ async def get_conversation_event(conversation_id: UUID, event_id: str) -> EventB
     return event
 
 
-@event_router.get("/")
+@event_router.get("")
 async def batch_get_conversation_events(
     conversation_id: UUID, event_ids: list[str]
 ) -> list[EventBase | None]:
@@ -110,7 +110,7 @@ async def batch_get_conversation_events(
     return events
 
 
-@event_router.post("/")
+@event_router.post("")
 async def send_message(conversation_id: UUID, request: SendMessageRequest) -> Success:
     """Send a message to a conversation"""
     event_service = await conversation_service.get_event_service(conversation_id)

--- a/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands/sdk/conversation/impl/remote_conversation.py
@@ -378,7 +378,7 @@ class RemoteConversation(BaseConversation):
                 "stuck_detection": stuck_detection,
                 "workspace": self.workspace.model_dump(),
             }
-            resp = self._client.post("/api/conversations/", json=payload)
+            resp = self._client.post("/api/conversations", json=payload)
             resp.raise_for_status()
             data = resp.json()
             # Expect a ConversationInfo

--- a/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands/sdk/conversation/impl/remote_conversation.py
@@ -461,7 +461,7 @@ class RemoteConversation(BaseConversation):
             "content": [c.model_dump() for c in message.content],
             "run": False,  # Mirror local semantics; explicit run() must be called
         }
-        resp = self._client.post(f"/api/conversations/{self._id}/events/", json=payload)
+        resp = self._client.post(f"/api/conversations/{self._id}/events", json=payload)
         resp.raise_for_status()
 
     def run(self) -> None:

--- a/tests/agent_server/test_api_authentication.py
+++ b/tests/agent_server/test_api_authentication.py
@@ -73,14 +73,14 @@ def test_api_no_auth_required(client):
 
 def test_api_auth_missing_key(client_with_auth):
     """Integration test: missing X-Session-API-Key should return 401."""
-    response = client_with_auth.get("/api/conversations/")
+    response = client_with_auth.get("/api/conversations")
     assert response.status_code == 401
 
 
 def test_api_auth_invalid_key(client_with_auth):
     """Integration test: invalid X-Session-API-Key should return 401."""
     response = client_with_auth.get(
-        "/api/conversations/", headers={"X-Session-API-Key": "wrong-key"}
+        "/api/conversations", headers={"X-Session-API-Key": "wrong-key"}
     )
     assert response.status_code == 401
 
@@ -88,7 +88,7 @@ def test_api_auth_invalid_key(client_with_auth):
 def test_api_auth_valid_key(client_with_auth):
     """Integration test: valid X-Session-API-Key should allow access."""
     response = client_with_auth.get(
-        "/api/conversations/", headers={"X-Session-API-Key": "test-key-123"}
+        "/api/conversations", headers={"X-Session-API-Key": "test-key-123"}
     )
     # Should not be 401 (might be other status depending on endpoint implementation)
     assert response.status_code != 401
@@ -98,7 +98,7 @@ def test_api_auth_multiple_keys_all_valid(client_with_multiple_keys):
     """Integration test: all configured keys should work."""
     for key in ["key-1", "key-2", "key-3"]:
         response = client_with_multiple_keys.get(
-            "/api/conversations/", headers={"X-Session-API-Key": key}
+            "/api/conversations", headers={"X-Session-API-Key": key}
         )
         assert response.status_code != 401, f"Key {key} should be valid"
 
@@ -106,7 +106,7 @@ def test_api_auth_multiple_keys_all_valid(client_with_multiple_keys):
 def test_api_auth_multiple_keys_invalid(client_with_multiple_keys):
     """Integration test: invalid key should fail with multiple keys configured."""
     response = client_with_multiple_keys.get(
-        "/api/conversations/", headers={"X-Session-API-Key": "invalid-key"}
+        "/api/conversations", headers={"X-Session-API-Key": "invalid-key"}
     )
     assert response.status_code == 401
 
@@ -121,7 +121,7 @@ def test_api_server_details_no_auth_required(client_with_auth):
 def test_api_protected_endpoints_require_auth(client_with_auth):
     """Test that API endpoints under /api prefix require authentication."""
     protected_endpoints = [
-        "/api/conversations/",
+        "/api/conversations",
         "/api/tools/",
         "/api/file/download/test.txt",
     ]
@@ -149,13 +149,13 @@ def test_api_case_sensitive_keys(client_with_auth):
 
     # Exact match should work
     response = client.get(
-        "/api/conversations/", headers={"X-Session-API-Key": "Test-Key-123"}
+        "/api/conversations", headers={"X-Session-API-Key": "Test-Key-123"}
     )
     assert response.status_code != 401
 
     # Case mismatch should fail
     response = client.get(
-        "/api/conversations/", headers={"X-Session-API-Key": "test-key-123"}
+        "/api/conversations", headers={"X-Session-API-Key": "test-key-123"}
     )
     assert response.status_code == 401
 
@@ -174,7 +174,7 @@ def test_api_header_case_insensitive():
     ]
 
     for header_name in header_variations:
-        response = client.get("/api/conversations/", headers={header_name: "test-key"})
+        response = client.get("/api/conversations", headers={header_name: "test-key"})
         assert response.status_code != 401, f"Header {header_name} should work"
 
 
@@ -192,7 +192,7 @@ def test_api_special_character_keys():
     client = TestClient(app, raise_server_exceptions=False)
 
     for key in special_keys:
-        response = client.get("/api/conversations/", headers={"X-Session-API-Key": key})
+        response = client.get("/api/conversations", headers={"X-Session-API-Key": key})
         assert response.status_code != 401, f"Special key {key} should work"
 
 
@@ -203,7 +203,7 @@ def test_api_empty_key_list():
     client = TestClient(app)
 
     # Should work without any authentication
-    response = client.get("/api/conversations/")
+    response = client.get("/api/conversations")
     assert response.status_code != 401
 
 
@@ -244,7 +244,7 @@ def test_api_options_requests():
     client = TestClient(app)
 
     # OPTIONS requests should work without authentication for CORS
-    response = client.options("/api/conversations/")
+    response = client.options("/api/conversations")
     # Should not be 401, might be 405 (Method Not Allowed) or 200
     assert response.status_code != 401
 
@@ -278,7 +278,7 @@ def test_api_multiple_concurrent_requests():
     responses = []
 
     for key in ["key-1", "key-2", "invalid-key"]:
-        response = client.get("/api/conversations/", headers={"X-Session-API-Key": key})
+        response = client.get("/api/conversations", headers={"X-Session-API-Key": key})
         responses.append((key, response.status_code))
 
     # Valid keys should work
@@ -295,7 +295,7 @@ def test_api_error_response_format():
     app = create_app(config)
     client = TestClient(app, raise_server_exceptions=False)
 
-    response = client.get("/api/conversations/")
+    response = client.get("/api/conversations")
     assert response.status_code == 401
 
     # The response might have additional details, but status code is most important


### PR DESCRIPTION
Right now, requests to some agent server endpoints require a trailing slash in order to work - without one they redirect to the endpoint with a slash. This is weird, so this PR changes the endpoints:

* `/api/conversations/` -> `/api/conversations`
* `/api/events/` -> `/api/events`