### PR TITLE
Creating a workspace object should not try to create the dir

### DIFF
--- a/openhands/sdk/workspace/local.py
+++ b/openhands/sdk/workspace/local.py
@@ -13,11 +13,6 @@ logger = get_logger(__name__)
 class LocalWorkspace(BaseWorkspace):
     """Mixin providing local workspace operations."""
 
-    def model_post_init(self, context: Any) -> None:
-        if not Path(self.working_dir).exists():
-            Path(self.working_dir).mkdir(parents=True, exist_ok=True)
-        return super().model_post_init(context)
-
     def execute_command(
         self,
         command: str,

--- a/openhands/sdk/workspace/remote.py
+++ b/openhands/sdk/workspace/remote.py
@@ -23,9 +23,6 @@ class RemoteWorkspace(BaseWorkspace):
     _client: httpx.Client = PrivateAttr()
 
     def model_post_init(self, context: Any) -> None:
-        if not Path(self.working_dir).exists():
-            Path(self.working_dir).mkdir(parents=True, exist_ok=True)
-
         # Set up remote host and API key
         self.host = self.host.rstrip("/")
         self.api_key = self.api_key


### PR DESCRIPTION
In the app server, I need to specify the Workspace inside the sandbox when creating it. Currently this means that it tries to create a /home/openhands/workspace directory locally.