### PR TITLE
feat: env path to docker building files not in packages

### DIFF
--- a/openhands/agent_server/docker/build.sh
+++ b/openhands/agent_server/docker/build.sh
@@ -72,11 +72,12 @@ fi
 # ------------------------------------------------------------
 # Build flags
 # ------------------------------------------------------------
+AGENT_SDK_PATH="${AGENT_SDK_PATH:-.}"
 COMMON_ARGS=(
   --build-arg "BASE_IMAGE=${BASE_IMAGE}"
   --target "${TARGET}"
   --file "${DOCKERFILE}"
-  .
+  $AGENT_SDK_PATH
 )
 
 echo "[build] Building target='${TARGET}' image='${IMAGE}' variant='${VARIANT_NAME}' from base='${BASE_IMAGE}' for platforms='${PLATFORMS}'"

--- a/openhands/sdk/sandbox/docker.py
+++ b/openhands/sdk/sandbox/docker.py
@@ -43,6 +43,13 @@ def _parse_build_tags(build_stdout: str) -> list[str]:
 
 
 def _resolve_build_script() -> Path | None:
+    # Check if AGENT_SDK_PATH environment variable is set
+    agent_sdk_path = os.environ.get("AGENT_SDK_PATH")
+    if agent_sdk_path:
+        p = Path(agent_sdk_path) / "openhands" / "agent_server" / "docker" / "build.sh"
+        if p.exists():
+            return p
+
     # Prefer locating via importlib without importing the module
     try:
         import importlib.util


### PR DESCRIPTION
When running the Agent Server from an imported package in another repository, docker.py needs to access build.sh which in turn will access DockerFile, uv.lock and wallpaper.svg
Those files are not in, and in the case of uv.lock should not be, inside the agent_server package.

Added environment variable AGENT_SDK_PATH that allows docker.py to access an external build.sh, and in turn build.sh to access the rest of the files.

This might get tricky because we are using two agent-sdk versions, the imported one in our repository and the external one used for building the image. 

Other solutions we might consider:
- Cloning from github a specified version.
- Using reflection to force the same version twice.