### PR TITLE
Remove Tool = ToolDefinition alias and Tool exports

### DIFF
--- a/openhands/sdk/__init__.py
+++ b/openhands/sdk/__init__.py
@@ -36,7 +36,6 @@ from openhands.sdk.mcp import (
 from openhands.sdk.tool import (
     Action,
     Observation,
-    Tool,
     ToolBase,
     ToolDefinition,
     ToolSpec,
@@ -66,7 +65,6 @@ __all__ = [
     "ImageContent",
     "ThinkingBlock",
     "RedactedThinkingBlock",
-    "Tool",
     "ToolDefinition",
     "ToolBase",
     "ToolSpec",

--- a/openhands/sdk/tool/__init__.py
+++ b/openhands/sdk/tool/__init__.py
@@ -13,7 +13,6 @@ from openhands.sdk.tool.schema import (
 from openhands.sdk.tool.spec import ToolSpec
 from openhands.sdk.tool.tool import (
     ExecutableTool,
-    Tool,
     ToolAnnotations,
     ToolBase,
     ToolDefinition,
@@ -23,7 +22,6 @@ from openhands.sdk.tool.tool import (
 
 __all__ = [
     "ToolDefinition",
-    "Tool",
     "ToolBase",
     "ToolSpec",
     "ToolAnnotations",

--- a/openhands/sdk/tool/tool.py
+++ b/openhands/sdk/tool/tool.py
@@ -362,7 +362,3 @@ def _create_action_type_with_risk(action_type: type[Action]) -> type[Action]:
     )
     _action_types_with_risk[action_type] = action_type_with_risk
     return action_type_with_risk
-
-
-# Backward compatibility aliases
-Tool = ToolDefinition


### PR DESCRIPTION
- Removed backward compatibility alias Tool = ToolDefinition from tool.py
- Removed Tool from imports and __all__ list in tool/__init__.py
- Removed Tool from imports and __all__ list in sdk/__init__.py
- All existing usage already uses ToolDefinition, no further replacements needed
- All tests passing (68/68 SDK tool tests, cross tests)