### PR TITLE
Fix StrReplaceEditor to include working directory in tool description

### DIFF
--- a/openhands/tools/str_replace_editor/definition.py
+++ b/openhands/tools/str_replace_editor/definition.py
@@ -225,11 +225,21 @@ class FileEditorTool(
         # Initialize the executor
         executor = FileEditorExecutor(workspace_root=conv_state.workspace.working_dir)
 
+        # Add working directory information to the tool description
+        # to guide the agent to use the correct directory instead of root
+        working_dir = conv_state.workspace.working_dir
+        enhanced_description = (
+            f"{TOOL_DESCRIPTION}\n\n"
+            f"Your current working directory is: {working_dir}\n"
+            f"When exploring project structure, start with this directory "
+            f"instead of the root filesystem."
+        )
+
         # Initialize the parent Tool with the executor
         return [
             cls(
                 name=str_replace_editor_tool.name,
-                description=TOOL_DESCRIPTION,
+                description=enhanced_description,
                 action_type=StrReplaceEditorAction,
                 observation_type=StrReplaceEditorObservation,
                 annotations=str_replace_editor_tool.annotations,

--- a/tests/tools/str_replace_editor/test_file_editor_tool.py
+++ b/tests/tools/str_replace_editor/test_file_editor_tool.py
@@ -180,3 +180,45 @@ def test_file_editor_tool_view_directory():
         assert not result.error
         assert "file1.txt" in result.output
         assert "file2.txt" in result.output
+
+
+def test_file_editor_tool_includes_working_directory_in_description():
+    """Test that FileEditorTool includes working directory info in description."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+        tools = FileEditorTool.create(conv_state)
+        tool = tools[0]
+
+        # Check that the tool description includes working directory information
+        assert f"Your current working directory is: {temp_dir}" in tool.description
+        assert (
+            "When exploring project structure, start with this directory "
+            "instead of the root filesystem."
+        ) in tool.description
+
+        # Verify the original description is still there
+        assert (
+            "Custom editing tool for viewing, creating and editing files"
+            in tool.description
+        )
+
+
+def test_file_editor_tool_openai_format_includes_working_directory():
+    """Test that OpenAI tool format includes working directory info."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+        tools = FileEditorTool.create(conv_state)
+        tool = tools[0]
+
+        # Convert to OpenAI tool format
+        openai_tool = tool.to_openai_tool()
+
+        # Check that the description includes working directory information
+        function_def = openai_tool["function"]
+        assert "description" in function_def
+        description = function_def["description"]
+        assert f"Your current working directory is: {temp_dir}" in description
+        assert (
+            "When exploring project structure, start with this directory "
+            "instead of the root filesystem."
+        ) in description


### PR DESCRIPTION
## Summary

This PR fixes issue #581 where StrReplaceEditor would start by exploring the root filesystem (`path: "/"`) instead of the current working directory, leading to inefficient and distracting behavior for agents.

## Problem

When agents use the StrReplaceEditor tool, they often start by exploring the project structure. However, without guidance about the current working directory, they would use `path: "/"` which lists the entire root filesystem, including system directories like `/Applications/`, `/usr/`, etc. This creates very long, irrelevant output that distracts the agent from the actual project files.

## Solution

Following the same approach used in the OpenHands CLI (referenced in the issue), this PR adds working directory information to the tool description. The fix:

1. **Modifies `FileEditorTool.create()`** to include working directory context in the tool description
2. **Adds clear guidance** telling agents to start exploration from the working directory instead of the root filesystem
3. **Preserves all existing functionality** while providing better context

## Changes

- **Modified**: `openhands/tools/str_replace_editor/definition.py`
  - Enhanced `FileEditorTool.create()` method to include working directory information in tool description
  - Added guidance text directing agents to use the working directory for project exploration

- **Added Tests**: `tests/tools/str_replace_editor/test_file_editor_tool.py`
  - `test_file_editor_tool_includes_working_directory_in_description()` - Verifies working directory info is in tool description
  - `test_file_editor_tool_openai_format_includes_working_directory()` - Verifies working directory info is preserved in OpenAI tool format

## Testing

- ✅ All existing tests continue to pass (135/135)
- ✅ New tests verify the working directory information is properly included
- ✅ Pre-commit hooks pass (ruff format, lint, pycodestyle, pyright)

## Example

Before this fix, agents would see a generic tool description. After this fix, they see:

```
Custom editing tool for viewing, creating and editing files in plain-text format

Your current working directory is: /path/to/project
When exploring project structure, start with this directory instead of the root filesystem.

[... rest of original description ...]
```

This guides agents to use `path: "/path/to/project"` instead of `path: "/"` when exploring the project structure.

Fixes #581

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ac6b8b4746014cd084c65f1ff8fb02ca)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:0571ea6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0571ea6-python \
  ghcr.io/all-hands-ai/agent-server:0571ea6-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:0571ea6-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:0571ea6-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:0571ea6-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `0571ea6` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->