### PR TITLE
Fix #581: Add workspace boundary validation to StrReplaceEditor

### DIFF
--- a/tests/tools/str_replace_editor/test_workspace_boundary.py
+++ b/tests/tools/str_replace_editor/test_workspace_boundary.py
@@ -1,0 +1,255 @@
+"""Tests for workspace boundary restrictions in FileEditor."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from openhands.tools.str_replace_editor.editor import FileEditor
+from openhands.tools.str_replace_editor.exceptions import (
+    EditorToolParameterInvalidError,
+)
+
+
+def test_workspace_boundary_view_outside_workspace(tmp_path):
+    """Test that viewing paths outside workspace is blocked when workspace_root is set."""  # noqa: E501
+    # Create a workspace root
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    # Create a file inside the workspace
+    test_file = workspace_root / "test.txt"
+    test_file.write_text("This is inside workspace")
+
+    # Initialize editor with workspace_root
+    editor = FileEditor(workspace_root=str(workspace_root))
+
+    # Test that accessing root directory is blocked
+    with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+        editor(command="view", path="/")
+
+    error_message = str(exc_info.value.message)
+    assert "Access denied" in error_message
+    assert "outside the allowed workspace directory" in error_message
+    assert str(workspace_root) in error_message
+
+
+def test_workspace_boundary_view_parent_directory(tmp_path):
+    """Test that viewing parent directories outside workspace is blocked."""
+    # Create a workspace root
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    # Initialize editor with workspace_root
+    editor = FileEditor(workspace_root=str(workspace_root))
+
+    # Test that accessing parent directory is blocked
+    parent_path = workspace_root.parent
+    with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+        editor(command="view", path=str(parent_path))
+
+    error_message = str(exc_info.value.message)
+    assert "Access denied" in error_message
+    assert "outside the allowed workspace directory" in error_message
+
+
+def test_workspace_boundary_view_inside_workspace_allowed(tmp_path):
+    """Test that viewing paths inside workspace is allowed."""
+    # Create a workspace root
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    # Create a subdirectory and file inside the workspace
+    subdir = workspace_root / "subdir"
+    subdir.mkdir()
+    test_file = subdir / "test.txt"
+    test_file.write_text("This is inside workspace")
+
+    # Initialize editor with workspace_root
+    editor = FileEditor(workspace_root=str(workspace_root))
+
+    # Test that accessing workspace root is allowed
+    result = editor(command="view", path=str(workspace_root))
+    assert not result.error  # error should be None or empty string
+    assert "subdir/" in result.output
+
+    # Test that accessing subdirectory is allowed
+    result = editor(command="view", path=str(subdir))
+    assert not result.error  # error should be None or empty string
+    assert "test.txt" in result.output
+
+    # Test that accessing file inside workspace is allowed
+    result = editor(command="view", path=str(test_file))
+    assert not result.error  # error should be None or empty string
+    assert "This is inside workspace" in result.output
+
+
+def test_workspace_boundary_create_outside_workspace(tmp_path):
+    """Test that creating files outside workspace is blocked."""
+    # Create a workspace root
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    # Initialize editor with workspace_root
+    editor = FileEditor(workspace_root=str(workspace_root))
+
+    # Test that creating file outside workspace is blocked
+    outside_file = tmp_path / "outside.txt"
+    with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+        editor(command="create", path=str(outside_file), file_text="content")
+
+    error_message = str(exc_info.value.message)
+    assert "Access denied" in error_message
+    assert "outside the allowed workspace directory" in error_message
+
+
+def test_workspace_boundary_str_replace_outside_workspace(tmp_path):
+    """Test that editing files outside workspace is blocked."""
+    # Create a file outside the workspace
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("original content")
+
+    # Create a workspace root
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    # Initialize editor with workspace_root
+    editor = FileEditor(workspace_root=str(workspace_root))
+
+    # Test that editing file outside workspace is blocked
+    with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+        editor(
+            command="str_replace",
+            path=str(outside_file),
+            old_str="original",
+            new_str="modified",
+        )
+
+    error_message = str(exc_info.value.message)
+    assert "Access denied" in error_message
+    assert "outside the allowed workspace directory" in error_message
+
+
+def test_workspace_boundary_symlink_outside_workspace(tmp_path):
+    """Test that symlinks pointing outside workspace are blocked."""
+    # Create a file outside the workspace
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("outside content")
+
+    # Create a workspace root
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    # Create a symlink inside workspace pointing to outside file
+    symlink_path = workspace_root / "symlink.txt"
+    symlink_path.symlink_to(outside_file)
+
+    # Initialize editor with workspace_root
+    editor = FileEditor(workspace_root=str(workspace_root))
+
+    # Test that accessing symlink pointing outside workspace is blocked
+    with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+        editor(command="view", path=str(symlink_path))
+
+    error_message = str(exc_info.value.message)
+    assert "Access denied" in error_message
+    assert "outside the allowed workspace directory" in error_message
+
+
+def test_workspace_boundary_no_workspace_root_allows_all(tmp_path):
+    """Test that when no workspace_root is set, all paths are allowed."""
+    # Create a file
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("test content")
+
+    # Initialize editor without workspace_root
+    editor = FileEditor()
+
+    # Test that accessing any absolute path is allowed
+    result = editor(command="view", path=str(test_file))
+    assert not result.error  # error should be None or empty string
+    assert "test content" in result.output
+
+
+def test_workspace_boundary_with_dot_dot_path(tmp_path):
+    """Test that paths with .. components outside workspace are blocked."""
+    # Create a workspace root
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    # Create a subdirectory inside workspace
+    subdir = workspace_root / "subdir"
+    subdir.mkdir()
+
+    # Initialize editor with workspace_root
+    editor = FileEditor(workspace_root=str(workspace_root))
+
+    # Test that accessing parent via .. is blocked when it goes outside workspace
+    parent_via_dotdot = subdir / ".." / ".."
+    with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+        editor(command="view", path=str(parent_via_dotdot))
+
+    error_message = str(exc_info.value.message)
+    assert "Access denied" in error_message
+    assert "outside the allowed workspace directory" in error_message
+
+
+def test_workspace_boundary_with_dot_dot_path_inside_workspace(tmp_path):
+    """Test that paths with .. components inside workspace are allowed."""
+    # Create a workspace root
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    # Create nested directories inside workspace
+    subdir1 = workspace_root / "subdir1"
+    subdir1.mkdir()
+    subdir2 = workspace_root / "subdir2"
+    subdir2.mkdir()
+    test_file = subdir2 / "test.txt"
+    test_file.write_text("test content")
+
+    # Initialize editor with workspace_root
+    editor = FileEditor(workspace_root=str(workspace_root))
+
+    # Test that accessing sibling directory via .. is allowed when it stays inside workspace  # noqa: E501
+    sibling_via_dotdot = subdir1 / ".." / "subdir2" / "test.txt"
+    result = editor(command="view", path=str(sibling_via_dotdot))
+    assert not result.error  # error should be None or empty string
+    assert "test content" in result.output
+
+
+def test_workspace_boundary_temp_directory_access():
+    """Test that accessing system temp directory is blocked when workspace is set."""
+    with tempfile.TemporaryDirectory() as workspace_root:
+        # Initialize editor with workspace_root
+        editor = FileEditor(workspace_root=workspace_root)
+
+        # Test that accessing system temp directory is blocked
+        system_temp = Path(tempfile.gettempdir())
+        if system_temp != Path(workspace_root):
+            with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+                editor(command="view", path=str(system_temp))
+
+            error_message = str(exc_info.value.message)
+            assert "Access denied" in error_message
+            assert "outside the allowed workspace directory" in error_message
+
+
+def test_workspace_boundary_home_directory_access(tmp_path):
+    """Test that accessing home directory is blocked when workspace is set."""
+    # Create a workspace root
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    # Initialize editor with workspace_root
+    editor = FileEditor(workspace_root=str(workspace_root))
+
+    # Test that accessing home directory is blocked
+    home_dir = Path.home()
+    if home_dir != workspace_root:
+        with pytest.raises(EditorToolParameterInvalidError) as exc_info:
+            editor(command="view", path=str(home_dir))
+
+        error_message = str(exc_info.value.message)
+        assert "Access denied" in error_message
+        assert "outside the allowed workspace directory" in error_message


### PR DESCRIPTION
## Summary

Fixes #581 by implementing workspace boundary validation for StrReplaceEditor to prevent exploration outside the working directory, similar to the fix implemented in OpenHands CLI.

## Problem

The StrReplaceEditor was allowing agents to explore the entire filesystem when using the `view` command with paths like `/`, which:
- Creates very long file listings that distract agents
- Is inefficient and unnecessary for most use cases
- Poses potential security concerns by exposing system directories

## Solution

This PR implements workspace boundary validation in the `FileEditor.validate_path()` method:

1. **Workspace Boundary Enforcement**: When `workspace_root` is explicitly provided, the editor now validates that all paths are within the workspace boundaries using `Path.relative_to()`.

2. **Backward Compatibility**: The validation only applies when `workspace_root` is explicitly set. Existing usage without `workspace_root` continues to work unchanged.

3. **Clear Error Messages**: When access is denied, users receive clear error messages indicating the path is outside the allowed workspace.

## Key Changes

### Core Implementation
- **Modified `FileEditor.__init__()`**: Added `_workspace_root_provided` flag to track when workspace_root is explicitly set
- **Enhanced `validate_path()` method**: Added workspace boundary validation using `Path.relative_to()` for robust path checking
- **Comprehensive validation**: Handles symlinks, relative paths with `..`, and absolute paths correctly

### Test Coverage
- **Added `test_workspace_boundary.py`**: 11 comprehensive test cases covering:
  - Blocking access outside workspace boundaries
  - Allowing access within workspace
  - Handling symlinks and `..` path components
  - Maintaining backward compatibility when no workspace_root is set
  - Testing various edge cases and scenarios

## Testing

- ✅ All existing tests pass (144/144) - no regressions
- ✅ All new tests pass (11/11) - comprehensive boundary validation
- ✅ Manual verification confirms the fix works as expected
- ✅ Pre-commit hooks pass (formatting, linting, type checking)

## Example Usage

```python
# With workspace_root set - boundary validation active
editor = FileEditor(workspace_root="/path/to/workspace")
result = editor(command="view", path="/")  # ❌ Blocked with clear error

# Without workspace_root - no boundary validation (backward compatible)
editor = FileEditor()
result = editor(command="view", path="/tmp")  # ✅ Allowed
```

## Verification

The fix successfully addresses the original issue:
- Agents can no longer explore outside their designated workspace
- File listings are now focused and relevant
- Existing functionality remains unchanged for backward compatibility

This implementation follows the same approach as the OpenHands CLI fix referenced in the issue comments.

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1560738eb0eb454d875822eba34bf722)