### PR TITLE
Fix MCP tool security risk prediction schema bug

### DIFF
--- a/examples/07_mcp_integration.py
+++ b/examples/07_mcp_integration.py
@@ -10,6 +10,7 @@ from openhands.sdk import (
     LLMConvertibleEvent,
     get_logger,
 )
+from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.tool import Tool, register_tool
 from openhands.tools.execute_bash import BashTool
 from openhands.tools.str_replace_editor import FileEditorTool
@@ -49,6 +50,7 @@ agent = Agent(
     mcp_config=mcp_config,
     # This regex filters out all repomix tools except pack_codebase
     filter_tools_regex="^(?!repomix)(.*)|^repomix.*pack_codebase.*$",
+    security_analyzer=LLMSecurityAnalyzer(),
 )
 
 llm_messages = []  # collect raw LLM messages

--- a/openhands/sdk/tool/tool.py
+++ b/openhands/sdk/tool/tool.py
@@ -292,7 +292,9 @@ class ToolBase[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         """
         action_type = action_type or self.action_type
 
-        action_type_with_risk = _create_action_type_with_risk(self.action_type)
+        action_type_with_risk = _create_action_type_with_risk(
+            action_type  # type: ignore[arg-type]
+        )
 
         # We only add security_risk if the tool is not read-only
         add_security_risk_prediction = add_security_risk_prediction and (

--- a/openhands/sdk/tool/tool.py
+++ b/openhands/sdk/tool/tool.py
@@ -292,9 +292,7 @@ class ToolBase[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         """
         action_type = action_type or self.action_type
 
-        action_type_with_risk = _create_action_type_with_risk(
-            action_type  # type: ignore[arg-type]
-        )
+        action_type_with_risk = _create_action_type_with_risk(action_type)
 
         # We only add security_risk if the tool is not read-only
         add_security_risk_prediction = add_security_risk_prediction and (
@@ -345,7 +343,7 @@ class ToolDefinition[ActionT, ObservationT](ToolBase[ActionT, ObservationT]):
         )
 
 
-def _create_action_type_with_risk(action_type: type[Action]) -> type[Action]:
+def _create_action_type_with_risk(action_type: type[Schema]) -> type[Schema]:
     action_type_with_risk = _action_types_with_risk.get(action_type)
     if action_type_with_risk:
         return action_type_with_risk

--- a/tests/sdk/mcp/test_mcp_security_risk.py
+++ b/tests/sdk/mcp/test_mcp_security_risk.py
@@ -1,0 +1,177 @@
+"""Tests for MCP tool with security risk prediction."""
+
+import mcp.types
+
+from openhands.sdk.mcp.client import MCPClient
+from openhands.sdk.mcp.definition import MCPToolAction, MCPToolObservation
+from openhands.sdk.mcp.tool import MCPToolDefinition
+
+
+class MockMCPClient(MCPClient):
+    """Mock MCPClient for testing that bypasses the complex constructor."""
+
+    def __init__(self):
+        # Skip the parent constructor to avoid needing transport
+        pass
+
+    def is_connected(self):
+        return True
+
+    async def call_tool_mcp(  # type: ignore[override]
+        self, name: str, arguments: dict
+    ):
+        """Mock implementation that returns a successful result."""
+        return mcp.types.CallToolResult(
+            content=[mcp.types.TextContent(type="text", text="Mock result")],
+            isError=False,
+        )
+
+    def call_async_from_sync(self, coro_func, timeout=None, **kwargs):
+        """Mock implementation for synchronous calling."""
+        import asyncio
+
+        async def wrapper():
+            async with self:
+                return await coro_func(**kwargs)
+
+        return asyncio.run(wrapper())
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def test_mcp_tool_to_openai_with_security_risk():
+    """Test that MCP tool schema includes security_risk field correctly.
+
+    This test reproduces the bug where MCP tools with security_risk enabled
+    incorrectly include both 'data' and 'security_risk' fields in the schema
+    instead of the actual tool parameters + security_risk.
+    """
+    # Create a fetch-like MCP tool
+    mcp_tool_def = mcp.types.Tool(
+        name="fetch_fetch",
+        description="Fetch a URL",
+        inputSchema={
+            "type": "object",
+            "properties": {"url": {"type": "string", "description": "URL to fetch"}},
+            "required": ["url"],
+        },
+    )
+
+    mock_client = MockMCPClient()
+    tools = MCPToolDefinition.create(mcp_tool=mcp_tool_def, mcp_client=mock_client)
+    tool = tools[0]
+
+    # Generate OpenAI tool schema WITH security risk prediction
+    openai_tool = tool.to_openai_tool(add_security_risk_prediction=True)
+
+    function_params = openai_tool["function"]["parameters"]  # type: ignore[typeddict-item]
+    properties = function_params["properties"]
+    required = function_params.get("required", [])
+
+    # The schema should have 'url' and 'security_risk' fields
+    # NOT 'data' and 'security_risk'
+    props_list = list(properties.keys())
+    assert "url" in properties, (
+        f"Expected 'url' field in properties, but got: {props_list}"
+    )
+    assert "security_risk" in properties, (
+        f"Expected 'security_risk' field in properties, but got: {props_list}"
+    )
+
+    # The schema should NOT have a 'data' field
+    assert "data" not in properties, (
+        f"Unexpected 'data' field in properties. Properties: {props_list}"
+    )
+
+    # Both fields should be required
+    assert "url" in required, f"Expected 'url' in required, but got: {required}"
+    assert "security_risk" in required, (
+        f"Expected 'security_risk' in required, but got: {required}"
+    )
+
+
+def test_mcp_tool_action_from_arguments_with_security_risk():
+    """Test that action_from_arguments works correctly with security_risk popped.
+
+    This test simulates what happens in Agent._get_action_event where
+    security_risk is popped from arguments before calling action_from_arguments.
+    """
+    # Create a fetch-like MCP tool
+    mcp_tool_def = mcp.types.Tool(
+        name="fetch_fetch",
+        description="Fetch a URL",
+        inputSchema={
+            "type": "object",
+            "properties": {"url": {"type": "string", "description": "URL to fetch"}},
+            "required": ["url"],
+        },
+    )
+
+    mock_client = MockMCPClient()
+    tools = MCPToolDefinition.create(mcp_tool=mcp_tool_def, mcp_client=mock_client)
+    tool = tools[0]
+
+    # Simulate LLM providing arguments with security_risk
+    # (security_risk would be popped by Agent before calling action_from_arguments)
+    arguments = {
+        "url": "https://google.com",
+        # security_risk has already been popped by Agent
+    }
+
+    # This should work and create an MCPToolAction with data field
+    action = tool.action_from_arguments(arguments)
+
+    assert isinstance(action, MCPToolAction)
+    assert action.data == {"url": "https://google.com"}
+
+
+def test_mcp_tool_validates_correctly_after_security_risk_pop():
+    """Test that MCP tool validation works after security_risk is popped.
+
+    This is the full integration test that reproduces the bug scenario:
+    1. LLM generates arguments based on schema with security_risk
+    2. Agent pops security_risk from arguments
+    3. Agent calls tool.action_from_arguments with remaining arguments
+    4. Tool should validate successfully (THIS IS WHERE THE BUG OCCURS)
+    """
+    # Create a fetch-like MCP tool
+    mcp_tool_def = mcp.types.Tool(
+        name="fetch_fetch",
+        description="Fetch a URL",
+        inputSchema={
+            "type": "object",
+            "properties": {"url": {"type": "string", "description": "URL to fetch"}},
+            "required": ["url"],
+        },
+    )
+
+    mock_client = MockMCPClient()
+    tools = MCPToolDefinition.create(mcp_tool=mcp_tool_def, mcp_client=mock_client)
+    tool = tools[0]
+
+    # Simulate what Agent does:
+    # 1. Parse arguments from LLM
+    llm_generated_arguments = {
+        "url": "https://google.com",
+        "security_risk": "LOW",
+    }
+
+    # 2. Pop security_risk (this is what Agent does in _get_action_event)
+    llm_generated_arguments.pop("security_risk")
+
+    # 3. Create action from remaining arguments
+    # This should NOT fail with validation errors about 'data' field
+    action = tool.action_from_arguments(llm_generated_arguments)
+
+    # Verify the action is created correctly
+    assert isinstance(action, MCPToolAction)
+    assert action.data == {"url": "https://google.com"}
+
+    # 4. Execute the action (this should also work)
+    observation = tool(action)
+    assert isinstance(observation, MCPToolObservation)
+    assert not observation.is_error


### PR DESCRIPTION
This PR fixes the issue where MCP tools were incorrectly using self.action_type instead of the action_type parameter when add_security_risk_prediction=True.

## Problem
When security risk prediction was enabled, MCP tools like fetch_fetch were generating OpenAI tool schemas with a generic 'data' field instead of the actual tool-specific parameters (e.g., 'url'). This caused validation errors when the LLM tried to call these tools.

## Solution
- Fixed tool.py line 295 to use the action_type parameter instead of self.action_type
- Added comprehensive test case test_mcp_security_risk.py to reproduce and verify the fix
- Added type ignore comments for known type system limitations

## Testing
- All MCP tests passing
- All tool definition tests passing
- New test specifically validates the fix

Fixes https://github.com/All-Hands-AI/OpenHands/issues/11210
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:9af17d4-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9af17d4-python \
  ghcr.io/all-hands-ai/agent-server:9af17d4-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:9af17d4-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:9af17d4-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:9af17d4-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `9af17d4` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->