### PR TITLE
Allow FileEditor insert_line to be 0 (start-of-file)

### DIFF
--- a/openhands/tools/file_editor/definition.py
+++ b/openhands/tools/file_editor/definition.py
@@ -50,11 +50,8 @@ class FileEditorAction(Action):
     insert_line: int | None = Field(
         default=None,
         ge=0,
-        description=(
-            "Required parameter of `insert` command. The `new_str` will be inserted"
-            " AFTER the line `insert_line` of `path`. Use 0 to insert at the"
-            " beginning of the file."
-        ),
+        description="Required parameter of `insert` command. The `new_str` will "
+        "be inserted AFTER the line `insert_line` of `path`.",
     )
     view_range: list[int] | None = Field(
         default=None,

--- a/openhands/tools/file_editor/definition.py
+++ b/openhands/tools/file_editor/definition.py
@@ -49,9 +49,12 @@ class FileEditorAction(Action):
     )
     insert_line: int | None = Field(
         default=None,
-        ge=1,
-        description="Required parameter of `insert` command. The `new_str` will "
-        "be inserted AFTER the line `insert_line` of `path`.",
+        ge=0,
+        description=(
+            "Required parameter of `insert` command. The `new_str` will be inserted"
+            " AFTER the line `insert_line` of `path`. Use 0 to insert at the"
+            " beginning of the file."
+        ),
     )
     view_range: list[int] | None = Field(
         default=None,


### PR DESCRIPTION
This `ge=0` sounds right to me, the LLM is told that `insert_line` is the line before the line at which to insert, so to insert on top of the file, it needs to be 0.

---

Summary
- Align File Editor tool schema with implementation by allowing insert_line to be 0 (beginning of file)
- Update description to clarify semantics and keep negative values invalid

Details
- The editor implementation already supports 0 <= insert_line <= num_lines and tests rely on insert_line=0 behavior (e.g., test_insert_chinese_text_into_english_file).
- Pydantic Field previously had ge=1; updated to ge=0 and expanded description.

Rationale
- Fixes mismatch between schema and runtime behavior

Validation
- pre-commit hooks pass (ruff, pyright, pycodestyle)
- Full test suite passes locally: 1480 passed, 38 warnings

Files changed
- openhands/tools/file_editor/definition.py

No changes to runtime behavior beyond schema validation; backward compatible.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5b339315c66f4865a5c00a5790cfe0e7)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:0fa7e4e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0fa7e4e-python \
  ghcr.io/all-hands-ai/agent-server:0fa7e4e-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:0fa7e4e-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:0fa7e4e-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:0fa7e4e-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `0fa7e4e` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->