### PR TITLE
LLM → Telemetry: fixes

### DIFF
--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -328,6 +328,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             model_name=self.model,
             log_enabled=self.log_completions,
             log_dir=self.log_completions_folder if self.log_completions else None,
+            input_cost_per_token=self.input_cost_per_token,
+            output_cost_per_token=self.output_cost_per_token,
             metrics=self._metrics,
         )
 

--- a/openhands/sdk/llm/utils/telemetry.py
+++ b/openhands/sdk/llm/utils/telemetry.py
@@ -231,7 +231,10 @@ class Telemetry(BaseModel):
                 ),
             )
             data = self._req_ctx.copy()
-            data["response"] = resp  # ModelResponse; serialized via _safe_json
+            data["response"] = (
+                resp  # ModelResponse | ResponsesAPIResponse;
+                # serialized via _safe_json
+            )
             data["cost"] = float(cost or 0.0)
             data["timestamp"] = time.time()
             data["latency_sec"] = self._last_latency
@@ -280,7 +283,8 @@ class Telemetry(BaseModel):
             # Raw response *before* nonfncall -> call conversion
             if raw_resp:
                 data["raw_response"] = (
-                    raw_resp  # ModelResponse; serialized via _safe_json
+                    raw_resp  # ModelResponse | ResponsesAPIResponse;
+                    # serialized via _safe_json
                 )
             # Pop duplicated tools to avoid logging twice
             if (

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -65,6 +65,10 @@ def mock_llm() -> LLM:
     mock_llm.reasoning_effort = None
     mock_llm.metadata = {}
 
+    # Explicitly set pricing attributes required by LLM -> Telemetry wiring
+    mock_llm.input_cost_per_token = None
+    mock_llm.output_cost_per_token = None
+
     mock_llm._metrics = None
 
     # Helper method to set mock response content

--- a/tests/sdk/llm/test_llm_pricing_passthrough.py
+++ b/tests/sdk/llm/test_llm_pricing_passthrough.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+from pydantic import SecretStr
+
+from openhands.sdk.llm import LLM, Message, TextContent
+from tests.conftest import create_mock_litellm_response
+
+
+def test_llm_pricing_passthrough_custom_rates():
+    """LLM should pass custom pricing to Telemetry (litellm cost calc).
+
+    Verifies that when LLM is constructed with input/output cost per token,
+    Telemetry._compute_cost forwards those via custom_cost_per_token to
+    litellm.cost_calculator.completion_cost.
+    """
+    with (
+        patch("openhands.sdk.llm.llm.litellm_completion") as mock_completion,
+        patch("openhands.sdk.llm.utils.telemetry.litellm_completion_cost") as mock_cost,
+    ):
+        mock_completion.return_value = create_mock_litellm_response("ok")
+        mock_cost.return_value = 0.123
+
+        llm = LLM(
+            service_id="test-llm",
+            model="gpt-4o",
+            api_key=SecretStr("test_key"),
+            input_cost_per_token=0.001,
+            output_cost_per_token=0.002,
+        )
+
+        messages = [Message(role="user", content=[TextContent(text="Hello")])]
+        llm.completion(messages=messages)
+
+        assert mock_cost.called, "litellm completion_cost should be invoked"
+        kwargs = mock_cost.call_args.kwargs
+        assert "custom_cost_per_token" in kwargs
+        cpt = kwargs["custom_cost_per_token"]
+        assert cpt["input_cost_per_token"] == 0.001
+        assert cpt["output_cost_per_token"] == 0.002


### PR DESCRIPTION
Addresses a few things from #637 

- LLM → Telemetry:
  - forward input_cost_per_token/output_cost_per_token so that it's actually used for custom cost
- Telemetry logging: 
  - de-duplicate tools (drop kwargs.tools)
  - serialize raw_response with model_dump() when available
  - use unique filenames with a short UUID suffix.
- Telemetry cost: 
  - intentionally skip recording 0.0; added inline comment clarifying policy.


All tests pass locally (1480 passed). Larger refactors from #637 are deferred to a follow-up.










<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:5ea2ff6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5ea2ff6-python \
  ghcr.io/all-hands-ai/agent-server:5ea2ff6-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:5ea2ff6-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:5ea2ff6-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:5ea2ff6-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `5ea2ff6` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->