### PR TITLE
refactor(llm): extract kwargs normalization into pure options selectors; remove deprecated _normalize_*

### DIFF
--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -423,7 +423,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # Only pass tools when native FC is active
         kwargs["tools"] = cc_tools if (bool(cc_tools) and use_native_fc) else None
         has_tools_flag = bool(cc_tools) and use_native_fc
-        call_kwargs = self._normalize_call_kwargs(kwargs, has_tools=has_tools_flag)
+        # Behavior-preserving: delegate to select_chat_options
+        from openhands.sdk.llm.options.chat_options import select_chat_options
+        call_kwargs = select_chat_options(self, kwargs, has_tools=has_tools_flag)
 
         # 4) optional request logging context (kept small)
         assert self._telemetry is not None
@@ -532,8 +534,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         )
 
         # Normalize/override Responses kwargs consistently
-        call_kwargs = self._normalize_responses_kwargs(
-            kwargs, include=include, store=store
+        from openhands.sdk.llm.options.responses_options import (
+            select_responses_options,
+        )
+        call_kwargs = select_responses_options(
+            self, kwargs, include=include, store=store
         )
 
         # Optional request logging
@@ -661,75 +666,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             litellm.modify_params = old
 
     def _normalize_call_kwargs(self, opts: dict, *, has_tools: bool) -> dict:
-        """Central place for provider quirks + param harmonization."""
-        out = dict(opts)
-
-        # Respect configured sampling params unless reasoning models override
-        if self.top_k is not None:
-            out.setdefault("top_k", self.top_k)
-        if self.top_p is not None:
-            out.setdefault("top_p", self.top_p)
-        if self.temperature is not None:
-            out.setdefault("temperature", self.temperature)
-
-        # Max tokens wiring differences
-        if self.max_output_tokens is not None:
-            # OpenAI-compatible param is `max_completion_tokens`
-            out.setdefault("max_completion_tokens", self.max_output_tokens)
-
-        # Azure -> uses max_tokens instead
-        if self.model.startswith("azure"):
-            if "max_completion_tokens" in out:
-                out["max_tokens"] = out.pop("max_completion_tokens")
-
-        # Reasoning-model quirks
-        if get_features(self.model).supports_reasoning_effort:
-            # Preferred: use reasoning_effort
-            if self.reasoning_effort is not None:
-                out["reasoning_effort"] = self.reasoning_effort
-            # Anthropic/OpenAI reasoning models ignore temp/top_p
-            out.pop("temperature", None)
-            out.pop("top_p", None)
-            # Gemini 2.5-pro default to low if not set
-            # otherwise litellm doesn't send reasoning, even though it happens
-            if "gemini-2.5-pro" in self.model:
-                if self.reasoning_effort in {None, "none"}:
-                    out["reasoning_effort"] = "low"
-
-        # Extended thinking models
-        if get_features(self.model).supports_extended_thinking:
-            if self.extended_thinking_budget:
-                out["thinking"] = {
-                    "type": "enabled",
-                    "budget_tokens": self.extended_thinking_budget,
-                }
-                # We need this to enable interleaved thinking
-                # https://docs.claude.com/en/docs/build-with-claude/extended-thinking#interleaved-thinking # noqa: E501
-                out["extra_headers"] = {
-                    "anthropic-beta": "interleaved-thinking-2025-05-14"
-                }
-                # We need this to fix a problematic behavior in litellm: https://github.com/BerriAI/litellm/blob/f6b67fd9bd6d019b08512eb9453fa5828977bad0/litellm/llms/base_llm/chat/transformation.py#L134-L144 # noqa: E501
-                out["max_tokens"] = self.max_output_tokens
-            # Anthropic models ignore temp/top_p
-            out.pop("temperature", None)
-            out.pop("top_p", None)
-
-        # Mistral / Gemini safety
-        if self.safety_settings:
-            ml = self.model.lower()
-            if "mistral" in ml or "gemini" in ml:
-                out["safety_settings"] = self.safety_settings
-
-        # Tools: if not using native, strip tool_choice so we don't confuse providers
-        if not has_tools:
-            out.pop("tools", None)
-            out.pop("tool_choice", None)
-
-        # non litellm proxy special-case: keep `extra_body` off unless model requires it
-        if "litellm_proxy" not in self.model:
-            out.pop("extra_body", None)
-
-        return out
+        """Deprecated: kept for backward compatibility; use options.select_chat_options."""
+        from openhands.sdk.llm.options.chat_options import select_chat_options
+        return select_chat_options(self, opts, has_tools=has_tools)
 
     def _normalize_responses_kwargs(
         self,
@@ -738,48 +677,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         include: list[str] | None,
         store: bool | None,
     ) -> dict:
-        """Central place to normalize kwargs for the Responses API path.
-
-        Policy:
-        - Start from user-provided opts and override a few keys consistently:
-          • temperature=1.0
-          • tool_choice="auto"
-          • include: append reasoning.encrypted_content if enabled
-          • store: defaults to False (unless explicitly provided)
-          • metadata: default to LLM.metadata if not provided
-          • max_output_tokens: default to LLM.max_output_tokens if not provided
-        """
-        out = dict(opts)
-
-        # Enforce sampling/tool behavior for Responses path
-        out["temperature"] = 1.0
-        out["tool_choice"] = "auto"
-
-        # Include encrypted reasoning if enabled
-        include_list = list(include) if include is not None else []
-        if (
-            self.enable_encrypted_reasoning
-            and "reasoning.encrypted_content" not in include_list
-        ):
-            include_list.append("reasoning.encrypted_content")
-        if include_list:
-            out["include"] = include_list
-
-        # Store defaults to False (stateless) unless explicitly provided
-        if store is not None:
-            out["store"] = bool(store)
-        else:
-            out.setdefault("store", False)
-
-        # Respect max_output_tokens if configured at LLM level
-        if self.max_output_tokens is not None:
-            out.setdefault("max_output_tokens", self.max_output_tokens)
-
-        # Request plaintext reasoning summary
-        effort = self.reasoning_effort or "high"
-        out["reasoning"] = {"effort": effort, "summary": "detailed"}
-
-        return out
+        """Deprecated: kept for backward compatibility; use options.select_responses_options."""
+        from openhands.sdk.llm.options.responses_options import (
+            select_responses_options,
+        )
+        return select_responses_options(self, opts, include=include, store=store)
 
     # =========================================================================
     # Capabilities, formatting, and info

--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -665,24 +665,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         finally:
             litellm.modify_params = old
 
-    def _normalize_call_kwargs(self, opts: dict, *, has_tools: bool) -> dict:
-        """Deprecated: kept for backward compatibility; use options.select_chat_options."""
-        from openhands.sdk.llm.options.chat_options import select_chat_options
-        return select_chat_options(self, opts, has_tools=has_tools)
-
-    def _normalize_responses_kwargs(
-        self,
-        opts: dict,
-        *,
-        include: list[str] | None,
-        store: bool | None,
-    ) -> dict:
-        """Deprecated: kept for backward compatibility; use options.select_responses_options."""
-        from openhands.sdk.llm.options.responses_options import (
-            select_responses_options,
-        )
-        return select_responses_options(self, opts, include=include, store=store)
-
     # =========================================================================
     # Capabilities, formatting, and info
     # =========================================================================

--- a/openhands/sdk/llm/options/__init__.py
+++ b/openhands/sdk/llm/options/__init__.py
@@ -1,0 +1,1 @@
+# options package for LLM parameter selection helpers

--- a/openhands/sdk/llm/options/chat_options.py
+++ b/openhands/sdk/llm/options/chat_options.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any
+
+from openhands.sdk.llm.utils.model_features import get_features
+
+
+def select_chat_options(llm, user_kwargs: dict[str, Any], has_tools: bool) -> dict[str, Any]:
+    """Behavior-preserving extraction of _normalize_call_kwargs.
+
+    This keeps the exact provider-aware mappings and precedence.
+    """
+    out = dict(user_kwargs)
+
+    # Respect configured sampling params unless reasoning models override
+    if llm.top_k is not None:
+        out.setdefault("top_k", llm.top_k)
+    if llm.top_p is not None:
+        out.setdefault("top_p", llm.top_p)
+    if llm.temperature is not None:
+        out.setdefault("temperature", llm.temperature)
+
+    # Max tokens wiring differences
+    if llm.max_output_tokens is not None:
+        # OpenAI-compatible param is `max_completion_tokens`
+        out.setdefault("max_completion_tokens", llm.max_output_tokens)
+
+    # Azure -> uses max_tokens instead
+    if llm.model.startswith("azure"):
+        if "max_completion_tokens" in out:
+            out["max_tokens"] = out.pop("max_completion_tokens")
+
+    # Reasoning-model quirks
+    if get_features(llm.model).supports_reasoning_effort:
+        # Preferred: use reasoning_effort
+        if llm.reasoning_effort is not None:
+            out["reasoning_effort"] = llm.reasoning_effort
+        # Anthropic/OpenAI reasoning models ignore temp/top_p
+        out.pop("temperature", None)
+        out.pop("top_p", None)
+        # Gemini 2.5-pro default to low if not set
+        if "gemini-2.5-pro" in llm.model:
+            if llm.reasoning_effort in {None, "none"}:
+                out["reasoning_effort"] = "low"
+
+    # Extended thinking models
+    if get_features(llm.model).supports_extended_thinking:
+        if llm.extended_thinking_budget:
+            out["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": llm.extended_thinking_budget,
+            }
+            # Enable interleaved thinking
+            out["extra_headers"] = {"anthropic-beta": "interleaved-thinking-2025-05-14"}
+            # Fix litellm behavior
+            out["max_tokens"] = llm.max_output_tokens
+        # Anthropic models ignore temp/top_p
+        out.pop("temperature", None)
+        out.pop("top_p", None)
+
+    # Mistral / Gemini safety
+    if llm.safety_settings:
+        ml = llm.model.lower()
+        if "mistral" in ml or "gemini" in ml:
+            out["safety_settings"] = llm.safety_settings
+
+    # Tools: if not using native, strip tool_choice so we don't confuse providers
+    if not has_tools:
+        out.pop("tools", None)
+        out.pop("tool_choice", None)
+
+    # non litellm proxy special-case: keep `extra_body` off unless model requires it
+    if "litellm_proxy" not in llm.model:
+        out.pop("extra_body", None)
+
+    return out

--- a/openhands/sdk/llm/options/common.py
+++ b/openhands/sdk/llm/options/common.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def coerce_and_default(user_kwargs: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
+    """Return a new dict with defaults applied when keys are absent.
+
+    - Pure and deterministic: no I/O, does not mutate inputs
+    - Only applies defaults when the key is missing and default is not None
+    - Does not coerce or alter user-provided values
+    - schema values can be literal defaults or callables returning a default
+    """
+    out = dict(user_kwargs)
+    for key, default in schema.items():
+        if key in out:
+            continue
+        if default is None:
+            continue
+        out[key] = default() if callable(default) else default
+    return out

--- a/openhands/sdk/llm/options/responses_options.py
+++ b/openhands/sdk/llm/options/responses_options.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from openhands.sdk.llm.options.common import coerce_and_default
+
 
 def select_responses_options(
     llm,
@@ -11,7 +13,13 @@ def select_responses_options(
     store: bool | None,
 ) -> dict[str, Any]:
     """Behavior-preserving extraction of _normalize_responses_kwargs."""
-    out = dict(user_kwargs)
+    # Apply defaults for keys that are not forced by policy
+    out = coerce_and_default(
+        user_kwargs,
+        {
+            "max_output_tokens": llm.max_output_tokens,
+        },
+    )
 
     # Enforce sampling/tool behavior for Responses path
     out["temperature"] = 1.0
@@ -29,10 +37,6 @@ def select_responses_options(
         out["store"] = bool(store)
     else:
         out.setdefault("store", False)
-
-    # Respect max_output_tokens if configured at LLM level
-    if llm.max_output_tokens is not None:
-        out.setdefault("max_output_tokens", llm.max_output_tokens)
 
     # Request plaintext reasoning summary
     effort = llm.reasoning_effort or "high"

--- a/tests/sdk/llm/test_responses_parsing_and_kwargs.py
+++ b/tests/sdk/llm/test_responses_parsing_and_kwargs.py
@@ -64,8 +64,10 @@ def test_normalize_responses_kwargs_policy():
     llm.enable_encrypted_reasoning = True
     llm.max_output_tokens = 128
 
-    out = llm._normalize_responses_kwargs(
-        {"temperature": 0.3}, include=["text.output_text"], store=None
+    from openhands.sdk.llm.options.responses_options import select_responses_options
+
+    out = select_responses_options(
+        llm, {"temperature": 0.3}, include=["text.output_text"], store=None
     )
     # Temperature forced to 1.0 for Responses path
     assert out["temperature"] == 1.0


### PR DESCRIPTION
Summary
- Extract behavior-preserving kwargs normalization into pure, deterministic helpers:
  - options/chat_options.py: select_chat_options(llm, user_kwargs: dict, has_tools: bool) -> dict
  - options/responses_options.py: select_responses_options(llm, user_kwargs: dict, include, store) -> dict
- Add tiny shared helper:
  - options/common.py: coerce_and_default(user_kwargs: dict, schema: dict) -> dict
    - Applies defaults only when keys are absent; does not coerce or mutate user values; pure and deterministic.
- Wire LLM.completion and LLM.responses to use new selectors (via direct imports); delete deprecated wrappers:
  - Removed LLM._normalize_call_kwargs and LLM._normalize_responses_kwargs
- Update tests to reference the selectors directly where needed.

Behavior preserved
- Cross-provider mappings and precedence are unchanged:
  - Azure: max_completion_tokens -> max_tokens
  - Reasoning models: set reasoning_effort if configured; drop temperature/top_p when required; Gemini 2.5-pro defaults reasoning_effort to "low" when none.
  - Extended thinking: set thinking payload with budget; add anthropic-beta interleaved-thinking header; set max_tokens workaround for litellm; drop temp/top_p for Anthropic-style.
  - Safety settings: passthrough for Mistral/Gemini where applicable.
  - Tools/tool_choice: stripped if not using native tools.
  - extra_body: dropped unless using litellm_proxy.
- Responses path policy retained:
  - temperature=1.0, tool_choice="auto"
  - include merges, plus reasoning.encrypted_content if enabled
  - store defaults to False
  - max_output_tokens defaulted from LLM config
  - reasoning: {effort: llm.reasoning_effort or "high", summary: "detailed"}

Why this refactor
- Simplifies the LLM surface with single-responsibility, testable selectors
- Guarantees purity and determinism for option selection
- Eases future providers/quirks by localizing mapping logic

Validation
- Ran focused SDK/LLM test subset locally (excluding agent_server server tests): 382 passed.
- No behavior changes intended; extraction is 1:1 plus minimal pure helper for default-only pass.

Notes
- No dependency changes.
- __init__.py added for options package.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/70f92965f52b4a9294289d9dc04cb4c7)