### PR TITLE
Remove automatic Chromium installation from browser tool

### DIFF
--- a/openhands/tools/browser_use/impl.py
+++ b/openhands/tools/browser_use/impl.py
@@ -86,24 +86,24 @@ def _ensure_chromium_available() -> str:
     """Ensure Chromium is available for browser operations.
 
     Raises:
-        Exception: If Chromium is not available and cannot be installed
+        Exception: If Chromium is not available
     """
     if path := _check_chromium_available():
         logger.info(f"Chromium is available for browser operations at {path}")
         return path
 
-    logger.info("Chromium not found, attempting auto-installation...")
-    if _install_chromium() and (path := _check_chromium_available()):
-        logger.info("Chromium successfully installed and verified")
-        return path
-
-    # Chromium not available and couldn't be installed
+    # Chromium not available - provide clear installation instructions
     error_msg = (
         "Chromium is required for browser operations but is not installed.\n\n"
         "To install Chromium, run one of the following commands:\n"
         "  1. Using uvx (recommended): uvx playwright install chromium "
         "--with-deps --no-shell\n"
-        "  2. Using pip: pip install playwright && playwright install chromium\n\n"
+        "  2. Using pip: pip install playwright && playwright install chromium\n"
+        "  3. Using system package manager:\n"
+        "     - Ubuntu/Debian: sudo apt install chromium-browser\n"
+        "     - macOS: brew install chromium\n"
+        "     - Windows: winget install Chromium.Chromium\n\n"
+        "After installation, restart your application to use the browser tool."
     )
     raise Exception(error_msg)
 

--- a/tests/tools/browser_use/test_chromium_detection.py
+++ b/tests/tools/browser_use/test_chromium_detection.py
@@ -208,49 +208,20 @@ class TestEnsureChromiumAvailable:
             result = _ensure_chromium_available()
             assert result == "/usr/bin/chromium"
 
-    def test_ensure_chromium_available_install_success(self):
-        """Test successful installation when Chromium not initially available."""
-        with (
-            patch(
-                "openhands.tools.browser_use.impl._check_chromium_available",
-                side_effect=[None, "/usr/bin/chromium"],
-            ),
-            patch(
-                "openhands.tools.browser_use.impl._install_chromium", return_value=True
-            ),
-        ):
-            result = _ensure_chromium_available()
-            assert result == "/usr/bin/chromium"
-
-    def test_ensure_chromium_available_install_failure(self):
-        """Test when Chromium installation fails."""
-        with (
-            patch(
-                "openhands.tools.browser_use.impl._check_chromium_available",
-                return_value=None,
-            ),
-            patch(
-                "openhands.tools.browser_use.impl._install_chromium", return_value=False
-            ),
+    def test_ensure_chromium_available_not_found_raises_error(self):
+        """Test that clear error is raised when Chromium is not available."""
+        with patch(
+            "openhands.tools.browser_use.impl._check_chromium_available",
+            return_value=None,
         ):
             with pytest.raises(Exception) as exc_info:
                 _ensure_chromium_available()
 
-            assert "Chromium is required for browser operations" in str(exc_info.value)
-            assert "uvx playwright install chromium" in str(exc_info.value)
-
-    def test_ensure_chromium_available_install_success_but_not_found(self):
-        """Test when installation succeeds but Chromium still not found."""
-        with (
-            patch(
-                "openhands.tools.browser_use.impl._check_chromium_available",
-                return_value=None,
-            ),
-            patch(
-                "openhands.tools.browser_use.impl._install_chromium", return_value=True
-            ),
-        ):
-            with pytest.raises(Exception) as exc_info:
-                _ensure_chromium_available()
-
-            assert "Chromium is required for browser operations" in str(exc_info.value)
+            error_message = str(exc_info.value)
+            assert "Chromium is required for browser operations" in error_message
+            assert "uvx playwright install chromium" in error_message
+            assert "pip install playwright" in error_message
+            assert "sudo apt install chromium-browser" in error_message
+            assert "brew install chromium" in error_message
+            assert "winget install Chromium.Chromium" in error_message
+            assert "restart your application" in error_message


### PR DESCRIPTION
## Summary

This PR removes the automatic Chromium installation behavior from the browser tool, addressing concerns that tools should not globally install software on the user's workstation without explicit permission.

## Problem

The browser tool previously attempted to automatically install Chromium if it wasn't found on the system. This was too intrusive as tools should not globally install software on the user's workstation without explicit permission.

## Solution

- **Modified `_ensure_chromium_available()`** to skip auto-installation and immediately raise a clear error when Chromium is not available
- **Enhanced error message** with comprehensive installation instructions including:
  - uvx (recommended): `uvx playwright install chromium --with-deps --no-shell`
  - pip: `pip install playwright && playwright install chromium`
  - System package managers for Ubuntu/Debian, macOS, and Windows
- **Updated tests** to reflect new behavior (no auto-installation)
- **Removed obsolete test cases** for installation scenarios

## Changes Made

### Core Implementation
- `openhands/tools/browser_use/impl.py`: Modified `_ensure_chromium_available()` to remove auto-installation logic and provide clear error messages

### Tests
- `tests/tools/browser_use/test_chromium_detection.py`: Updated tests to verify new error behavior and removed obsolete installation test cases

## Benefits

1. **Respects user choice** - Users decide how and when to install Chromium
2. **System integrity** - No unexpected software installations
3. **Clear guidance** - Comprehensive error messages guide users to install Chromium using their preferred method
4. **Better UX** - Users understand exactly what they need to do instead of waiting for potentially failing auto-installation

## Testing

- ✅ All existing tests pass
- ✅ New test verifies comprehensive error message content
- ✅ Pre-commit hooks (formatting, linting, type checking) pass
- ✅ Manual verification shows clear error messages when Chromium is unavailable

## Backward Compatibility

This is a breaking change in behavior, but it's a positive change that:
- Prevents unwanted software installation
- Provides clearer error messages
- Maintains the same API surface

Users who relied on auto-installation will now receive clear instructions on how to install Chromium manually.

Co-authored-by: openhands <openhands@all-hands.dev>

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bc61390e2b55413b807f614942aac028)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:7bcc74e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7bcc74e-python \
  ghcr.io/all-hands-ai/agent-server:7bcc74e-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:7bcc74e-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:7bcc74e-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:7bcc74e-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `7bcc74e` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->