### PR TITLE
Replace LITELLM_API_KEY with LLM_API_KEY in examples

### DIFF
--- a/examples/01_hello_world.py
+++ b/examples/01_hello_world.py
@@ -15,8 +15,8 @@ from openhands.tools.preset.default import get_default_agent
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",
     base_url="https://llm-proxy.eval.all-hands.dev",

--- a/examples/02_custom_tools.py
+++ b/examples/02_custom_tools.py
@@ -116,8 +116,8 @@ _GREP_DESCRIPTION = """Fast content search tool.
 """  # noqa: E501
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/03_activate_microagent.py
+++ b/examples/03_activate_microagent.py
@@ -23,8 +23,8 @@ from openhands.tools.file_editor import FileEditorTool
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/04_confirmation_mode_example.py
+++ b/examples/04_confirmation_mode_example.py
@@ -77,8 +77,8 @@ def run_until_finished(conversation: BaseConversation, confirmer: Callable) -> N
 
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/05_use_llm_registry.py
+++ b/examples/05_use_llm_registry.py
@@ -20,8 +20,8 @@ from openhands.tools.execute_bash import BashTool
 logger = get_logger(__name__)
 
 # Configure LLM using LLMRegistry
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 
 # Create LLM instance
 main_llm = LLM(

--- a/examples/06_interactive_terminal_w_reasoning.py
+++ b/examples/06_interactive_terminal_w_reasoning.py
@@ -17,8 +17,8 @@ from openhands.tools.execute_bash import BashTool
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     # model="litellm_proxy/gemini/gemini-2.5-pro",

--- a/examples/07_mcp_integration.py
+++ b/examples/07_mcp_integration.py
@@ -19,8 +19,8 @@ from openhands.tools.file_editor import FileEditorTool
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/08_mcp_with_oauth.py
+++ b/examples/08_mcp_with_oauth.py
@@ -18,8 +18,8 @@ from openhands.tools.file_editor import FileEditorTool
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/09_pause_example.py
+++ b/examples/09_pause_example.py
@@ -16,8 +16,8 @@ from openhands.tools.file_editor import FileEditorTool
 
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/10_persistence.py
+++ b/examples/10_persistence.py
@@ -19,8 +19,8 @@ from openhands.tools.file_editor import FileEditorTool
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/11_async.py
+++ b/examples/11_async.py
@@ -28,8 +28,8 @@ from openhands.tools.task_tracker import TaskTrackerTool
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/12_custom_secrets.py
+++ b/examples/12_custom_secrets.py
@@ -14,8 +14,8 @@ from openhands.tools.file_editor import FileEditorTool
 
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="claude-sonnet-4-20250514",

--- a/examples/13_get_llm_metrics.py
+++ b/examples/13_get_llm_metrics.py
@@ -18,8 +18,8 @@ from openhands.tools.file_editor import FileEditorTool
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/14_context_condenser.py
+++ b/examples/14_context_condenser.py
@@ -27,8 +27,8 @@ from openhands.tools.task_tracker import TaskTrackerTool
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/15_browser_use.py
+++ b/examples/15_browser_use.py
@@ -19,8 +19,8 @@ from openhands.tools.file_editor import FileEditorTool
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/16_llm_security_analyzer.py
+++ b/examples/16_llm_security_analyzer.py
@@ -89,8 +89,8 @@ def run_until_finished_with_security(
 
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="security-analyzer",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/17_image_input.py
+++ b/examples/17_image_input.py
@@ -29,8 +29,8 @@ from openhands.tools.task_tracker import TaskTrackerTool
 logger = get_logger(__name__)
 
 # Configure LLM (vision-capable model)
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="vision-llm",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/18_send_message_while_processing.py
+++ b/examples/18_send_message_while_processing.py
@@ -56,8 +56,8 @@ from openhands.tools.file_editor import FileEditorTool
 
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/19_llm_routing.py
+++ b/examples/19_llm_routing.py
@@ -20,8 +20,8 @@ from openhands.tools.preset.default import get_default_tools
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 
 primary_llm = LLM(
     service_id="agent-primary",

--- a/examples/20_stuck_detector.py
+++ b/examples/20_stuck_detector.py
@@ -15,8 +15,8 @@ from openhands.tools.preset.default import get_default_agent
 logger = get_logger(__name__)
 
 # Configure LLM
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 llm = LLM(
     service_id="agent",
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",

--- a/examples/21_generate_extraneous_conversation_costs.py
+++ b/examples/21_generate_extraneous_conversation_costs.py
@@ -22,8 +22,8 @@ from openhands.tools.execute_bash import (
 logger = get_logger(__name__)
 
 # Configure LLM using LLMRegistry
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 
 # Create LLM instance
 llm = LLM(

--- a/examples/22_hello_world_with_agent_server.py
+++ b/examples/22_hello_world_with_agent_server.py
@@ -117,8 +117,8 @@ class ManagedAPIServer:
             print("API server stopped.")
 
 
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 
 llm = LLM(
     service_id="agent",

--- a/examples/23_hello_world_with_sandboxed_server.py
+++ b/examples/23_hello_world_with_sandboxed_server.py
@@ -18,8 +18,8 @@ logger = get_logger(__name__)
 
 def main() -> None:
     # 1) Ensure we have LLM API key
-    api_key = os.getenv("LITELLM_API_KEY")
-    assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+    api_key = os.getenv("LLM_API_KEY")
+    assert api_key is not None, "LLM_API_KEY environment variable is not set."
 
     llm = LLM(
         service_id="agent",
@@ -35,7 +35,7 @@ def main() -> None:
         host_port=8010,
         # TODO: Change this to your platform if not linux/arm64
         platform="linux/arm64",
-        forward_env=["LITELLM_API_KEY"],  # Forward API key to container
+        forward_env=["LLM_API_KEY"],  # Forward API key to container
     ) as workspace:
         # 3) Create agent
         agent = get_default_agent(

--- a/examples/24_browser_use_with_sandboxed_server.py
+++ b/examples/24_browser_use_with_sandboxed_server.py
@@ -13,8 +13,8 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
-    api_key = os.getenv("LITELLM_API_KEY")
-    assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+    api_key = os.getenv("LLM_API_KEY")
+    assert api_key is not None, "LLM_API_KEY environment variable is not set."
 
     llm = LLM(
         service_id="agent",
@@ -30,7 +30,7 @@ def main() -> None:
         # TODO: Change this to your platform if not linux/arm64
         platform="linux/arm64",
         extra_ports=True,  # Expose extra ports for VSCode and VNC
-        forward_env=["LITELLM_API_KEY"],  # Forward API key to container
+        forward_env=["LLM_API_KEY"],  # Forward API key to container
     ) as workspace:
         """Extra ports allows you to check localhost:8012 for VNC"""
 

--- a/examples/25_anthropic_thinking.py
+++ b/examples/25_anthropic_thinking.py
@@ -18,8 +18,8 @@ from openhands.tools.execute_bash import BashTool
 
 
 # Configure LLM for Anthropic Claude with extended thinking
-api_key = os.getenv("LITELLM_API_KEY")
-assert api_key is not None, "LITELLM_API_KEY environment variable is not set."
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
 
 llm = LLM(
     service_id="agent",

--- a/examples/26_responses_reasoning.py
+++ b/examples/26_responses_reasoning.py
@@ -24,8 +24,8 @@ from openhands.tools.preset.default import get_default_agent
 logger = get_logger(__name__)
 
 
-api_key = os.getenv("LITELLM_API_KEY") or os.getenv("OPENAI_API_KEY")
-assert api_key, "Set LITELLM_API_KEY or OPENAI_API_KEY in your environment."
+api_key = os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+assert api_key, "Set LLM_API_KEY or OPENAI_API_KEY in your environment."
 
 model = os.getenv("OPENAI_RESPONSES_MODEL", "openai/gpt-5-mini")
 base_url = os.getenv("LITELLM_BASE_URL", "https://llm-proxy.eval.all-hands.dev")


### PR DESCRIPTION
## Summary

Replace all occurrences of `LITELLM_API_KEY` with `LLM_API_KEY` throughout the examples directory to maintain consistency with OpenHands v1 and reduce cognitive load for users who don't need to know about LiteLLM implementation details.

## Changes

- **26 example files modified** (all Python files in `examples/` directory)
- **54 total replacements** including:
  - `os.getenv("LITELLM_API_KEY")` → `os.getenv("LLM_API_KEY")`
  - Error message strings
  - `forward_env` parameter in Docker workspace examples

## Rationale

- Maintains consistency with OpenHands v1 naming conventions
- Reduces cognitive load - users don't need to understand LiteLLM internals
- More generic name is clearer for SDK users

## Testing

- All pre-commit hooks passed:
  - ✅ Ruff format
  - ✅ Ruff lint
  - ✅ PEP8 style check (pycodestyle)
  - ✅ Type check with Pyright (strict)

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/342022bc272c494f9d6e8db18e74c6f2)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:f6428e3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f6428e3-python \
  ghcr.io/all-hands-ai/agent-server:f6428e3-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:f6428e3-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:f6428e3-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:f6428e3-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `f6428e3` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->