### PR TITLE
Fix: Robust Sonnet 4.5 detection incl. Bedrock dotted vendor prefixes; skip default reasoning_effort for Sonnet 4.5

### DIFF
--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -284,7 +284,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # default reasoning_effort unless Gemini 2.5
         # (we keep consistent with old behavior)
         if d.get("reasoning_effort") is None and (
-            "gemini-2.5-pro" not in model_val and "claude-sonnet-4-5" not in model_val
+            "gemini-2.5-pro" not in model_val
+            and "claude-sonnet-4-5" not in model_val
+            and "claude-sonnet-4.5" not in model_val
         ):
             d["reasoning_effort"] = "high"
 

--- a/openhands/sdk/llm/utils/model_features.py
+++ b/openhands/sdk/llm/utils/model_features.py
@@ -37,9 +37,11 @@ def normalize_model_name(model: str) -> str:
         "amazon",
     }
     if "." in name:
-        vendor, rest = name.split(".", 1)
-        if vendor in vendor_prefixes and rest:
-            name = rest
+        tokens = name.split(".")
+        for idx, token in enumerate(tokens):
+            if token in vendor_prefixes and idx + 1 < len(tokens):
+                name = ".".join(tokens[idx + 1 :])
+                break
 
     if name.endswith("-gguf"):
         name = name[: -len("-gguf")]
@@ -125,6 +127,7 @@ EXTENDED_THINKING_PATTERNS: list[str] = [
     # We did not include sonnet 3.7 and 4 here as they don't brings
     # significant performance improvements for agents
     "claude-sonnet-4-5*",
+    "claude-sonnet-4.5*",
 ]
 
 PROMPT_CACHE_PATTERNS: list[str] = [


### PR DESCRIPTION
fix All-Hands-AI/OpenHands#11248

Summary
- Normalize Bedrock-style region.vendor prefixes (e.g., `us.anthropic.*`) so Sonnet 4.5 is recognized as extended-thinking model
- Add pattern for dot variant (`claude-sonnet-4.5*`) in addition to dash variant
- Avoid applying default `reasoning_effort` to Claude Sonnet 4.5 (both `-` and `.` variants)
- As a result, temperature/top_p are correctly suppressed for Sonnet 4.5 extended-thinking models to prevent Bedrock 400 errors

Details
- openhands/sdk/llm/utils/model_features.py
  - normalize_model_name: strips dotted prefixes up to the first known vendor (anthropic, meta, cohere, mistral, ai21, amazon); handles cases like `bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0` -> `claude-sonnet-4-5-20250929-v1`
  - EXTENDED_THINKING_PATTERNS: added `claude-sonnet-4.5*`
- openhands/sdk/llm/llm.py
  - Default reasoning_effort logic updated to skip Sonnet 4.5 dot variant
  - Extended thinking path continues to pop `temperature` and `top_p`

No dependency changes.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/367caf2d7f944e42b6ba7c200765481b)