### PR TITLE
Add GitHub Actions workflow for scheduled maintenance tasks

### DIFF
--- a/.github/workflows/maintenance-task.yml
+++ b/.github/workflows/maintenance-task.yml
@@ -1,0 +1,101 @@
+---
+name: Scheduled Maintenance Task
+
+on:
+    # Allow manual trigger with custom parameters
+    workflow_dispatch:
+        inputs:
+            agent_script:
+                description: "The Python script to run for the maintenance task"
+                required: false
+                type: string
+                default: "examples/28_maintenance_task_runner.py"
+            prompt_location:
+                description: "URL or file path to the prompt (Jinja2 template)"
+                required: true
+                type: string
+            llm_model:
+                description: "LLM model to use"
+                required: false
+                type: string
+                default: "anthropic/claude-sonnet-4-5-20250929"
+            llm_base_url:
+                description: "Optional base URL for the LLM API"
+                required: false
+                type: string
+    # Scheduled trigger (disabled by default, uncomment and customize as needed)
+    # schedule:
+    #   # Run at 2 AM UTC every day
+    #   - cron: "0 2 * * *"
+
+permissions:
+    contents: write
+    pull-requests: write
+    issues: write
+
+jobs:
+    run-maintenance-task:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  enable-cache: true
+
+            - name: Install dependencies
+              run: uv sync --frozen --group dev
+
+            - name: Check required environment variables
+              env:
+                  LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+                  LLM_MODEL: >-
+                      ${{ secrets.LLM_MODEL || inputs.llm_model ||
+                      'anthropic/claude-sonnet-4-5-20250929' }}
+                  LLM_BASE_URL: ${{ secrets.LLM_BASE_URL || inputs.llm_base_url }}
+              run: |
+                  if [ -z "$LLM_API_KEY" ]; then
+                    echo "Error: LLM_API_KEY secret is not set."
+                    exit 1
+                  fi
+
+                  echo "Using LLM model: $LLM_MODEL"
+                  if [ -n "$LLM_BASE_URL" ]; then
+                    echo "Using LLM base URL: $LLM_BASE_URL"
+                  fi
+
+            - name: Run maintenance task
+              env:
+                  LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+                  LLM_MODEL: >-
+                      ${{ secrets.LLM_MODEL || inputs.llm_model ||
+                      'anthropic/claude-sonnet-4-5-20250929' }}
+                  LLM_BASE_URL: ${{ secrets.LLM_BASE_URL || inputs.llm_base_url }}
+                  AGENT_SCRIPT: >-
+                      ${{ inputs.agent_script ||
+                      'examples/28_maintenance_task_runner.py' }}
+                  PROMPT_LOCATION: >-
+                      ${{ inputs.prompt_location ||
+                      'https://example.com/prompt.txt' }}
+                  PYTHONPATH: ""
+              run: |
+                  echo "Running agent script: $AGENT_SCRIPT"
+                  echo "With prompt from: $PROMPT_LOCATION"
+                  uv run python "$AGENT_SCRIPT" "$PROMPT_LOCATION"
+
+            - name: Upload logs as artifact
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: maintenance-task-logs
+                  path: |
+                      *.log
+                      output/
+                  retention-days: 7

--- a/README.md
+++ b/README.md
@@ -253,6 +253,57 @@ The agent server provides:
 - `POST /conversations/{id}/messages` - Send message to conversation
 - `WebSocket /ws/{conversation_id}` - Real-time conversation updates
 
+## Scheduled Maintenance Tasks
+
+The SDK includes a GitHub Actions workflow for running scheduled maintenance tasks with the agent. This allows you to automate recurring operations like dependency updates, security audits, or documentation maintenance.
+
+### Features
+
+- **Configurable schedule**: Run tasks at fixed intervals using cron syntax
+- **Remote prompts**: Load task instructions from URLs or local files
+- **Flexible LLM configuration**: Customize model, API key, and base URL
+- **Custom scripts**: Use your own agent scripts for specialized tasks
+
+### Quick Start
+
+1. **Create a prompt file** with your task instructions:
+
+```text
+Check the repository for any outdated dependencies and create a summary report.
+```
+
+2. **Run locally** to test:
+
+```bash
+export LLM_API_KEY="your-api-key"
+export LLM_MODEL="anthropic/claude-sonnet-4-5-20250929"
+python examples/28_maintenance_task_runner.py examples/prompts/maintenance_example.txt
+```
+
+3. **Configure GitHub Actions** (`.github/workflows/maintenance-task.yml`):
+   - Set `LLM_API_KEY` secret in your repository settings
+   - Optionally set `LLM_MODEL` and `LLM_BASE_URL` secrets
+   - Uncomment and customize the cron schedule
+   - Run manually or wait for scheduled execution
+
+4. **Manual workflow dispatch**:
+   - Go to Actions → "Scheduled Maintenance Task"
+   - Click "Run workflow"
+   - Provide prompt location (file path or URL)
+   - Configure LLM settings as needed
+
+### Configuration Options
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `AGENT_SCRIPT` | Python script to run the agent | `examples/28_maintenance_task_runner.py` |
+| `PROMPT_LOCATION` | URL or path to prompt file | Required |
+| `LLM_MODEL` | Language model to use | `anthropic/claude-sonnet-4-5-20250929` |
+| `LLM_API_KEY` | API key for the LLM | Required (from secrets) |
+| `LLM_BASE_URL` | Optional base URL for LLM API | None |
+
+See [`examples/prompts/README.md`](examples/prompts/README.md) for more examples and best practices.
+
 ## Development Workflow
 
 ### Environment Setup

--- a/examples/28_maintenance_task_runner.py
+++ b/examples/28_maintenance_task_runner.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Example script for running maintenance tasks with OpenHands agent.
+
+This script accepts a prompt from a file or URL and runs the agent to execute
+the maintenance task. It's designed to be used with GitHub Actions for
+scheduled maintenance tasks.
+
+Usage:
+    python 28_maintenance_task_runner.py <prompt_location>
+
+Arguments:
+    prompt_location: Path to a local file or URL containing the prompt
+"""
+
+import argparse
+import os
+import sys
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+from pydantic import SecretStr
+
+from openhands.sdk import LLM, Conversation, Event, LLMConvertibleEvent, get_logger
+from openhands.tools.preset.default import get_default_agent
+
+
+logger = get_logger(__name__)
+
+
+def is_url(path: str) -> bool:
+    """Check if the given path is a URL."""
+    try:
+        result = urlparse(path)
+        return all([result.scheme, result.netloc])
+    except Exception:
+        return False
+
+
+def load_prompt(prompt_location: str) -> str:
+    """
+    Load prompt from a file or URL.
+
+    Args:
+        prompt_location: Path to a local file or URL containing the prompt
+
+    Returns:
+        The prompt content as a string
+
+    Raises:
+        ValueError: If the prompt cannot be loaded
+    """
+    try:
+        if is_url(prompt_location):
+            logger.info(f"Downloading prompt from URL: {prompt_location}")
+            with urlopen(prompt_location) as response:
+                return response.read().decode("utf-8")
+        else:
+            logger.info(f"Loading prompt from file: {prompt_location}")
+            with open(prompt_location) as f:
+                return f.read()
+    except Exception as e:
+        raise ValueError(f"Failed to load prompt from {prompt_location}: {e}")
+
+
+def main():
+    """Run the maintenance task with the provided prompt."""
+    parser = argparse.ArgumentParser(
+        description="Run OpenHands agent for maintenance tasks"
+    )
+    parser.add_argument(
+        "prompt_location",
+        help="Path to a local file or URL containing the prompt",
+    )
+    args = parser.parse_args()
+
+    # Load the prompt
+    try:
+        prompt = load_prompt(args.prompt_location)
+        logger.info(f"Loaded prompt ({len(prompt)} characters)")
+    except ValueError as e:
+        logger.error(str(e))
+        sys.exit(1)
+
+    # Configure LLM
+    api_key = os.getenv("LLM_API_KEY")
+    if not api_key:
+        logger.error("LLM_API_KEY environment variable is not set.")
+        sys.exit(1)
+
+    model = os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929")
+    base_url = os.getenv("LLM_BASE_URL")
+
+    llm_config = {
+        "model": model,
+        "api_key": SecretStr(api_key),
+        "service_id": "maintenance_task",
+        "drop_params": True,
+    }
+
+    if base_url:
+        llm_config["base_url"] = base_url
+
+    llm = LLM(**llm_config)
+
+    # Get the current working directory as workspace
+    cwd = os.getcwd()
+
+    # Create agent with default tools
+    agent = get_default_agent(
+        llm=llm,
+        cli_mode=True,
+    )
+
+    # Collect LLM messages for logging
+    llm_messages = []
+
+    def conversation_callback(event: Event):
+        if isinstance(event, LLMConvertibleEvent):
+            llm_messages.append(event.to_llm_message())
+
+    # Create conversation
+    conversation = Conversation(
+        agent=agent,
+        callbacks=[conversation_callback],
+        workspace=cwd,
+    )
+
+    logger.info("Starting maintenance task execution...")
+    logger.info(f"Prompt: {prompt[:200]}...")
+
+    # Send the prompt and run the agent
+    conversation.send_message(prompt)
+    conversation.run()
+
+    logger.info("Maintenance task completed successfully")
+    logger.info(f"Total LLM messages: {len(llm_messages)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/prompts/README.md
+++ b/examples/prompts/README.md
@@ -1,0 +1,43 @@
+# Maintenance Task Prompts
+
+This directory contains example prompts for scheduled maintenance tasks.
+
+## Usage
+
+These prompts can be used with the `28_maintenance_task_runner.py` script or the GitHub Actions workflow.
+
+### Running locally
+
+```bash
+python examples/28_maintenance_task_runner.py examples/prompts/maintenance_example.txt
+```
+
+### Using with GitHub Actions
+
+1. Go to the Actions tab in your repository
+2. Select "Scheduled Maintenance Task" workflow
+3. Click "Run workflow"
+4. Enter the path or URL to your prompt file
+5. Configure other parameters as needed
+
+## Creating Custom Prompts
+
+Create a plain text file with your task instructions. The prompt will be passed directly to the OpenHands agent.
+
+Example:
+```
+Update all copyright headers in the repository to the current year.
+
+Please:
+1. Find all files with copyright notices
+2. Update the year to 2025
+3. Create a summary of changes made
+```
+
+## Using Remote Prompts
+
+You can also host prompts on the web and reference them by URL:
+
+```bash
+python examples/28_maintenance_task_runner.py https://example.com/prompts/weekly-cleanup.txt
+```

--- a/examples/prompts/maintenance_example.txt
+++ b/examples/prompts/maintenance_example.txt
@@ -1,0 +1,6 @@
+Check the repository for any outdated dependencies and create a summary report.
+
+Please:
+1. List all Python dependencies defined in pyproject.toml files
+2. Check if there are any known security vulnerabilities
+3. Provide a summary of findings in a markdown file called DEPENDENCY_REPORT.md


### PR DESCRIPTION
## Description

This PR implements a configurable GitHub Actions workflow for running scheduled maintenance tasks using the OpenHands agent SDK, as requested in issue #671.

## Changes

### 1. Example Script (`examples/28_maintenance_task_runner.py`)
- Accepts prompt locations as command-line arguments (file paths or URLs)
- Supports loading prompts from local files or remote URLs
- Configures LLM from environment variables
- Uses the default agent preset with CLI mode

### 2. GitHub Actions Workflow (`.github/workflows/maintenance-task.yml`)
- **Manual trigger** (workflow_dispatch) with configurable inputs:
  - `agent_script`: Custom agent script path (default: `examples/28_maintenance_task_runner.py`)
  - `prompt_location`: URL or file path to prompt (required)
  - `llm_model`: LLM model to use (default: `anthropic/claude-sonnet-4-5-20250929`)
  - `llm_base_url`: Optional base URL for LLM API
- **Scheduled trigger** (cron) - commented out by default for safety
- Supports secrets for `LLM_API_KEY`, `LLM_MODEL`, and `LLM_BASE_URL`
- Includes artifact upload for logs

### 3. Example Prompts and Documentation
- Created `examples/prompts/` directory with:
  - Sample prompt file for dependency checking
  - README with usage examples and best practices
- Updated main README with comprehensive "Scheduled Maintenance Tasks" section

## Configuration

Users can configure the workflow by:
1. Setting GitHub secrets (`LLM_API_KEY`, optionally `LLM_MODEL` and `LLM_BASE_URL`)
2. Running manually via Actions tab
3. Uncommenting and customizing the cron schedule for automated runs
4. Creating custom prompt files for specific maintenance tasks

## Testing

- ✅ Python script passes ruff linting and formatting
- ✅ YAML workflow file is valid
- ✅ Example prompt and documentation created
- ✅ README updated with usage guide

## Related Issue

Fixes #671

## Example Usage

### Local Testing
```bash
export LLM_API_KEY="your-api-key"
export LLM_MODEL="anthropic/claude-sonnet-4-5-20250929"
python examples/28_maintenance_task_runner.py examples/prompts/maintenance_example.txt
```

### GitHub Actions
1. Go to Actions → "Scheduled Maintenance Task"
2. Click "Run workflow"
3. Enter prompt location and configure LLM settings
4. Click "Run workflow"

## Notes

- The cron schedule is commented out by default to prevent accidental automated runs
- Users should test with manual dispatch before enabling scheduled runs
- Prompts can be hosted remotely for easy updates without code changes

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8f89ed35eb774ccdb01a42fd8e715223)