### PR TITLE
fix: prevent tests from making HTTP calls to production LLM proxy

### DIFF
--- a/openhands/agent_server/conversation_router.py
+++ b/openhands/agent_server/conversation_router.py
@@ -35,10 +35,9 @@ START_CONVERSATION_EXAMPLES = [
     StartConversationRequest(
         agent=Agent(
             llm=LLM(
-                service_id="test-llm",
-                model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",
-                base_url="https://llm-proxy.app.all-hands.dev",
-                api_key=SecretStr("secret"),
+                service_id="your-llm-service",
+                model="your-model-provider/your-model-name",
+                api_key=SecretStr("your-api-key-here"),
             ),
             tools=[
                 Tool(name="BashTool"),

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from litellm.exceptions import (
@@ -37,13 +37,20 @@ def test_llm_init_with_default_config(default_llm):
     assert default_llm.metrics.model_name == "gpt-4o"
 
 
-def test_base_url_for_openhands_provider():
+@patch("openhands.sdk.llm.llm.httpx.get")
+def test_base_url_for_openhands_provider(mock_get):
+    """Test that openhands/ prefix automatically sets base_url to production proxy."""
+    # Mock the model info fetch to avoid actual HTTP calls to production
+    mock_get.return_value = Mock(json=lambda: {"data": []})
+
     llm = LLM(
         model="openhands/claude-sonnet-4-20250514",
         api_key=SecretStr("test-key"),
         service_id="test-openhands-llm",
     )
     assert llm.base_url == "https://llm-proxy.app.all-hands.dev/"
+    # Verify the mocked HTTP call was attempted
+    mock_get.assert_called_once()
 
 
 def test_token_usage_add():


### PR DESCRIPTION
## Problem

Tests and example code were creating LLM instances with production/staging URLs and fake API keys, causing repeated HTTP requests to production infrastructure during test runs.

### Root Cause

- During `LLM.__init__`, the `_init_model_info_and_caps()` method makes an HTTP GET request to `{base_url}/v1/model/info`
- Tests were using real production URLs (`llm-proxy.app.all-hands.dev`) with fake API keys like `'secret'` or `'fake-secret'`
- This caused authentication errors and log spam on every test run, putting unnecessary stress on the router

## Solution

### 1. tests/sdk/llm/test_llm.py
- Added `@patch` decorator to mock `httpx.get` in `test_base_url_for_openhands_provider`
- Mock returns empty model info to prevent actual HTTP calls
- Test still validates that the `openhands/` prefix correctly sets the `base_url`

### 2. openhands/agent_server/conversation_router.py
- Changed `START_CONVERSATION_EXAMPLES` to use obvious placeholder values
- Removed production URL (no `base_url` set - users should provide their own)
- Changed model from `'litellm_proxy/anthropic/claude-sonnet-4-5-20250929'` to `'your-model-provider/your-model-name'`
- Changed api_key from `'secret'` to `'your-api-key-here'`

## Changes

```diff
# tests/sdk/llm/test_llm.py
+ @patch("openhands.sdk.llm.llm.httpx.get")
+ def test_base_url_for_openhands_provider(mock_get):
+     # Mock the model info fetch to avoid actual HTTP calls to production
+     mock_get.return_value = Mock(json=lambda: {"data": []})
```

```diff
# openhands/agent_server/conversation_router.py
- service_id="test-llm",
- model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",
- base_url="https://llm-proxy.app.all-hands.dev",
- api_key=SecretStr("secret"),
+ service_id="your-llm-service",
+ model="your-model-provider/your-model-name",
+ api_key=SecretStr("your-api-key-here"),
```

## Testing

✅ All 23 tests in `test_llm.py` continue to pass
✅ Pre-commit checks pass (ruff format, ruff lint, pycodestyle, pyright)
✅ Verified no HTTP calls to `all-hands.dev` servers during test runs
✅ Verified no calls to `/v1/model/info` endpoint during example imports

## Impact

- ✅ Tests no longer spam production infrastructure with fake credentials
- ✅ Example code uses obvious placeholders that won't accidentally work
- ✅ No breaking changes - all existing tests continue to pass
- ✅ Improves developer experience by reducing noise in production logs

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7cbb9d2ab28f49b7afa99cf9824a1d40)